### PR TITLE
Fix the order of HTTP2 headers in Firefox

### DIFF
--- a/firefox/patches/curl-http2-c.patch
+++ b/firefox/patches/curl-http2-c.patch
@@ -1,0 +1,8 @@
+--- curl-7.81.0-original/lib/http2.c	2022-01-03 18:36:46.000000000 +0200
++++ curl-7.81.0/lib/http2.c	2022-02-19 20:21:06.381022445 +0200
+@@ -1820,3 +1820,4 @@
+    field list. */
+-#define AUTHORITY_DST_IDX 3
++/* curl-impersonate: Put the ":authority" header in the second place. */
++#define AUTHORITY_DST_IDX 2
+ 


### PR DESCRIPTION
I noticed that, while our TLS handshake was perfectly impersonating Firefox, the session was still being detected at the HTTP2 level. From my testing this PR seems to solve that. I will leave it open for a few days to let people test and comment.