### PR TITLE
Fix bug in wrapper scripts parameter passing

### DIFF
--- a/chrome/curl_chrome98
+++ b/chrome/curl_chrome98
@@ -23,4 +23,4 @@ dir=`echo "$0" | sed 's%/[^/]*$%%'`
     --http2 --false-start --compressed \
     --tlsv1.2 --no-npn --alps \
     --cert-compression brotli \
-    $@
+    "$@"

--- a/chrome/curl_edge98
+++ b/chrome/curl_edge98
@@ -23,4 +23,4 @@ dir=`echo "$0" | sed 's%/[^/]*$%%'`
     --http2 --false-start --compressed \
     --tlsv1.2 --no-npn --alps \
     --cert-compression brotli \
-    $@
+    "$@"

--- a/firefox/curl_ff91esr
+++ b/firefox/curl_ff91esr
@@ -19,4 +19,4 @@ dir=`echo "$0" | sed 's%/[^/]*$%%'`
     -H 'Sec-Fetch-Site: none' \
     -H 'Sec-Fetch-User: ?1' \
     --http2 --false-start --compressed \
-    $@
+    "$@"

--- a/firefox/curl_ff95
+++ b/firefox/curl_ff95
@@ -19,4 +19,4 @@ dir=`echo "$0" | sed 's%/[^/]*$%%'`
     -H 'Sec-Fetch-Site: none' \
     -H 'Sec-Fetch-User: ?1' \
     --http2 --false-start --compressed \
-    $@
+    "$@"


### PR DESCRIPTION
Parameters to the wrapper scripts were passed incorrectly to
the 'curl-impersonate' binary.

Resolves #18 