### PR TITLE
Fix Edge and Firefox HTTP headers

### DIFF
--- a/chrome/curl_edge98
+++ b/chrome/curl_edge98
@@ -13,7 +13,7 @@ dir=`echo "$0" | sed 's%/[^/]*$%%'`
     -H 'sec-ch-ua-platform: "Windows"' \
     -H 'Upgrade-Insecure-Requests: 1' \
     -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36 Edg/98.0.1108.62' \
-    -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9' \
+    -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9' \
     -H 'Sec-Fetch-Site: none' \
     -H 'Sec-Fetch-Mode: navigate' \
     -H 'Sec-Fetch-User: ?1' \

--- a/chrome/patches/curl-impersonate.patch
+++ b/chrome/patches/curl-impersonate.patch
@@ -85,7 +85,7 @@ index 2dbfb26b5..e0bf86169 100644
   * NAME curl_easy_getinfo()
   *
 diff --git a/lib/easy.c b/lib/easy.c
-index 20293a710..58941c5a6 100644
+index 20293a710..5f2a3e166 100644
 --- a/lib/easy.c
 +++ b/lib/easy.c
 @@ -80,6 +80,7 @@
@@ -204,7 +204,7 @@ index 20293a710..58941c5a6 100644
 +      "sec-ch-ua-platform: \"Windows\"",
 +      "Upgrade-Insecure-Requests: 1",
 +      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36 Edg/98.0.1108.62",
-+      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
 +      "Sec-Fetch-Site: none",
 +      "Sec-Fetch-Mode: navigate",
 +      "Sec-Fetch-User: ?1",

--- a/firefox/curl_ff91esr
+++ b/firefox/curl_ff91esr
@@ -9,14 +9,14 @@ dir=`echo "$0" | sed 's%/[^/]*$%%'`
 "$dir/curl-impersonate" \
     --ciphers aes_128_gcm_sha_256,chacha20_poly1305_sha_256,aes_256_gcm_sha_384,ecdhe_ecdsa_aes_128_gcm_sha_256,ecdhe_rsa_aes_128_gcm_sha_256,ecdhe_ecdsa_chacha20_poly1305_sha_256,ecdhe_rsa_chacha20_poly1305_sha_256,ecdhe_ecdsa_aes_256_gcm_sha_384,ecdhe_rsa_aes_256_gcm_sha_384,ecdhe_ecdsa_aes_256_sha,ecdhe_ecdsa_aes_128_sha,ecdhe_rsa_aes_128_sha,ecdhe_rsa_aes_256_sha,rsa_aes_128_gcm_sha_256,rsa_aes_256_gcm_sha_384,rsa_aes_128_sha,rsa_aes_256_sha,rsa_3des_ede_cbc_sha \
     -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0' \
-    -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' \
+    -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' \
     -H 'Accept-Language: en-US,en;q=0.5' \
     -H 'Accept-Encoding: gzip, deflate, br' \
-    -H 'Connection: keep-alive' \
     -H 'Upgrade-Insecure-Requests: 1' \
     -H 'Sec-Fetch-Dest: document' \
     -H 'Sec-Fetch-Mode: navigate' \
     -H 'Sec-Fetch-Site: none' \
     -H 'Sec-Fetch-User: ?1' \
+    -H 'TE: Trailers' \
     --http2 --false-start --compressed \
     $@

--- a/firefox/curl_ff95
+++ b/firefox/curl_ff95
@@ -12,11 +12,11 @@ dir=`echo "$0" | sed 's%/[^/]*$%%'`
     -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' \
     -H 'Accept-Language: en-US,en;q=0.5' \
     -H 'Accept-Encoding: gzip, deflate, br' \
-    -H 'Connection: keep-alive' \
     -H 'Upgrade-Insecure-Requests: 1' \
     -H 'Sec-Fetch-Dest: document' \
     -H 'Sec-Fetch-Mode: navigate' \
     -H 'Sec-Fetch-Site: none' \
     -H 'Sec-Fetch-User: ?1' \
+    -H 'TE: Trailers' \
     --http2 --false-start --compressed \
     $@

--- a/firefox/patches/curl-impersonate.patch
+++ b/firefox/patches/curl-impersonate.patch
@@ -57,7 +57,7 @@ index 2dbfb26b5..e0bf86169 100644
   * NAME curl_easy_getinfo()
   *
 diff --git a/lib/easy.c b/lib/easy.c
-index 20293a710..b0b4c2751 100644
+index 20293a710..1a4d52d2f 100644
 --- a/lib/easy.c
 +++ b/lib/easy.c
 @@ -80,6 +80,7 @@
@@ -112,15 +112,15 @@ index 20293a710..b0b4c2751 100644
 +      "rsa_3des_ede_cbc_sha",
 +    .http_headers = {
 +      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0",
-+      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
 +      "Accept-Language: en-US,en;q=0.5",
 +      "Accept-Encoding: gzip, deflate, br",
-+      "Connection: keep-alive",
 +      "Upgrade-Insecure-Requests: 1",
 +      "Sec-Fetch-Dest: document",
 +      "Sec-Fetch-Mode: navigate",
 +      "Sec-Fetch-Site: none",
-+      "Sec-Fetch-User: ?1"
++      "Sec-Fetch-User: ?1",
++      "TE: Trailers"
 +    }
 +  },
 +  {
@@ -150,12 +150,12 @@ index 20293a710..b0b4c2751 100644
 +      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
 +      "Accept-Language: en-US,en;q=0.5",
 +      "Accept-Encoding: gzip, deflate, br",
-+      "Connection: keep-alive",
 +      "Upgrade-Insecure-Requests: 1",
 +      "Sec-Fetch-Dest: document",
 +      "Sec-Fetch-Mode: navigate",
 +      "Sec-Fetch-Site: none",
-+      "Sec-Fetch-User: ?1"
++      "Sec-Fetch-User: ?1",
++      "TE: Trailers"
 +    }
 +  }
 +};


### PR DESCRIPTION
The HTTP headers for Edge and Firefox were slightly incorrect.

curl patches from
https://github.com/lwthiker/curl/commit/ee0a67058ff5b4e3d0aaa4650feb584c68f80182
and
https://github.com/lwthiker/curl/commit/351dba44d02524c0b5df84309db593bc31143662