### PR TITLE
Compile libbrotli statically into curl-impersonate

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ The resulting image contains:
 
 You can use them inside the docker, copy them out using `docker cp` or use them in a multi-stage docker build.
 
-If you use them outside the container, install the following dependencies: `sudo apt install libbrotli1`
-
 ### Firefox build
 Build with:
 ```
@@ -71,8 +69,7 @@ The resulting image contains:
 * `/build/out/curl_ff91esr`, `/build/out/curl_ff95` - Wrapper scripts that launch `curl-impersonate` with all the needed flags.
 * `/build/out/libcurl-impersonate.so` - libcurl compiled with impersonation support. See [libcurl-impersonate](#libcurl-impersonate) below for more details.
 
-If you use it outside the container, install the following dependencies:
-* `sudo apt install libbrotli1`
+If you use it outside the container, install the following dependency:
 * `sudo apt install libnss3`.  Even though nss is statically compiled into `curl-impersonate`, it is still necessary to install libnss3 because curl dynamically loads `libnssckbi.so`, a file containing Mozilla's list of trusted root certificates. Alternatively, use `curl -k` to disable certificate verification.
 
 ### Distro packages

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -5,11 +5,20 @@ WORKDIR /build
 
 # Dependencies for downloading and building BoringSSL
 RUN apt-get update && \
-    apt-get install -y git g++ cmake golang-go ninja-build curl unzip zlib1g-dev libbrotli-dev
+    apt-get install -y git g++ cmake golang-go ninja-build curl unzip zlib1g-dev
 
 # The following are needed because we are going to change some autoconf scripts,
 # both for libnghttp2 and curl.
 RUN apt-get install -y autoconf automake autotools-dev pkg-config libtool
+
+# Download and compile libbrotli
+ARG BROTLI_VERSION=1.0.9
+RUN curl -L https://github.com/google/brotli/archive/refs/tags/v${BROTLI_VERSION}.tar.gz -o brotli-${BROTLI_VERSION}.tar.gz && \
+    tar xf brotli-${BROTLI_VERSION}.tar.gz
+RUN cd brotli-${BROTLI_VERSION} && \
+    mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./installed .. && \
+    cmake --build . --config Release --target install
 
 # BoringSSL doesn't have versions. Choose a commit that is used in a stable
 # Chromium version.
@@ -24,7 +33,7 @@ COPY patches/boringssl-*.patch boringssl/
 RUN cd boringssl && \
     for p in $(ls boringssl-*.patch); do patch -p1 < $p; done && \
     mkdir build && cd build && \
-    cmake -DCMAKE_POSITION_INDEPENDENT_CODE=on -GNinja .. && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=on -GNinja .. && \
     ninja
 
 # Fix the directory structure so that curl can compile against it.
@@ -66,7 +75,14 @@ RUN cd ${CURL_VERSION} && \
 # Compile curl with BoringSSL & nghttp2.
 # Enable keylogfile for debugging of TLS traffic.
 RUN cd ${CURL_VERSION} && \
-    ./configure --with-openssl=/build/boringssl/build --enable-static --disable-shared --with-nghttp2=/usr/local LIBS="-pthread" CFLAGS="-I/build/boringssl/build" USE_CURL_SSLKEYLOGFILE=true && \
+    ./configure --enable-static \
+                --disable-shared \
+                --with-openssl=/build/boringssl/build \
+                --with-nghttp2=/usr/local \
+                --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
+                LIBS="-pthread" \
+                CFLAGS="-I/build/boringssl/build" \
+                USE_CURL_SSLKEYLOGFILE=true && \
     make
 
 RUN mkdir out && \
@@ -77,6 +93,7 @@ RUN mkdir out && \
 RUN cd ${CURL_VERSION} && \
     ./configure --with-openssl=/build/boringssl/build \
                 --with-nghttp2=/usr/local \
+                --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 LIBS="-pthread" \
                 CFLAGS="-I/build/boringssl/build" \
                 USE_CURL_SSLKEYLOGFILE=true && \

--- a/chrome/patches/curl-impersonate.patch
+++ b/chrome/patches/curl-impersonate.patch
@@ -1,8 +1,31 @@
 diff --git a/configure.ac b/configure.ac
-index 63e320236..deb054300 100644
+index 63e320236..5870fa430 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2573,15 +2573,15 @@ if test X"$want_nghttp2" != Xno; then
+@@ -1331,7 +1331,8 @@ if test X"$OPT_BROTLI" != Xno; then
+ 
+   dnl if given with a prefix, we set -L and -I based on that
+   if test -n "$PREFIX_BROTLI"; then
+-    LIB_BROTLI="-lbrotlidec"
++    # curl-impersonate: Use static libbrotli
++    LIB_BROTLI="-Wl,-Bstatic -lbrotlidec-static -lbrotlicommon-static -Wl,-Bdynamic"
+     LD_BROTLI=-L${PREFIX_BROTLI}/lib$libsuff
+     CPP_BROTLI=-I${PREFIX_BROTLI}/include
+     DIR_BROTLI=${PREFIX_BROTLI}/lib$libsuff
+@@ -1341,7 +1342,11 @@ if test X"$OPT_BROTLI" != Xno; then
+   CPPFLAGS="$CPPFLAGS $CPP_BROTLI"
+   LIBS="$LIB_BROTLI $LIBS"
+ 
+-  AC_CHECK_LIB(brotlidec, BrotliDecoderDecompress)
++  AC_CHECK_LIB(brotlidec, BrotliDecoderDecompress,
++    # curl-impersonate: Define 'action-if-found' explicitly to prevent
++    # -lbrotlidec from being added to LIBS (already added before)
++    AC_DEFINE(HAVE_LIBBROTLI, 1, [Define to 1 if libbrotli exists])
++  )
+ 
+   AC_CHECK_HEADERS(brotli/decode.h,
+     curl_brotli_msg="enabled (libbrotlidec)"
+@@ -2573,15 +2578,15 @@ if test X"$want_nghttp2" != Xno; then
  
    if test "$PKGCONFIG" != "no" ; then
      LIB_H2=`CURL_EXPORT_PCDIR([$want_nghttp2_path])

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /build
 # Dependencies for building libnss
 # See https://firefox-source-docs.mozilla.org/security/nss/build.html#mozilla-projects-nss-building
 RUN apt-get update && \
-    apt-get install -y mercurial git ninja-build python3-pip curl zlib1g-dev libbrotli-dev
+    apt-get install -y mercurial git ninja-build cmake python3-pip curl zlib1g-dev
 
 # The following are needed because we are going to change some autoconf scripts,
 # both for libnghttp2 and curl.
@@ -17,7 +17,16 @@ RUN apt-get install -y autoconf automake autotools-dev pkg-config libtool
 # which is supplied by libnss3 on Debian/Ubuntu
 RUN apt-get install -y libnss3
 
-# Also needed for building libnss
+# Download and compile libbrotli
+ARG BROTLI_VERSION=1.0.9
+RUN curl -L https://github.com/google/brotli/archive/refs/tags/v${BROTLI_VERSION}.tar.gz -o brotli-${BROTLI_VERSION}.tar.gz && \
+    tar xf brotli-${BROTLI_VERSION}.tar.gz
+RUN cd brotli-${BROTLI_VERSION} && \
+    mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./installed .. && \
+    cmake --build . --config Release --target install
+
+# Needed for building libnss
 RUN pip install gyp-next
 
 ARG NSS_VERSION=nss-3.74
@@ -61,7 +70,13 @@ RUN cd ${CURL_VERSION} && \
 
 # Compile curl with nss
 RUN cd ${CURL_VERSION} && \
-    ./configure --with-nss=/build/${NSS_VERSION}/dist/Release --enable-static --disable-shared CFLAGS="-I/build/${NSS_VERSION}/dist/public/nss -I/build/${NSS_VERSION}/dist/Release/include/nspr" --with-nghttp2=/usr/local USE_CURL_SSLKEYLOGFILE=true && \
+    ./configure --enable-static \
+                --disable-shared \
+                --with-nss=/build/${NSS_VERSION}/dist/Release \
+                --with-nghttp2=/usr/local \
+                --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
+                CFLAGS="-I/build/${NSS_VERSION}/dist/public/nss -I/build/${NSS_VERSION}/dist/Release/include/nspr" \
+                USE_CURL_SSLKEYLOGFILE=true && \
     make
 
 RUN mkdir out && \
@@ -72,6 +87,7 @@ RUN mkdir out && \
 RUN cd ${CURL_VERSION} && \
     ./configure --with-nss=/build/${NSS_VERSION}/dist/Release \
                 --with-nghttp2=/usr/local \
+                --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 CFLAGS="-I/build/${NSS_VERSION}/dist/public/nss -I/build/${NSS_VERSION}/dist/Release/include/nspr" \
                 USE_CURL_SSLKEYLOGFILE=true && \
     make clean && make

--- a/firefox/patches/curl-impersonate.patch
+++ b/firefox/patches/curl-impersonate.patch
@@ -1,8 +1,31 @@
 diff --git a/configure.ac b/configure.ac
-index 63e320236..deb054300 100644
+index 63e320236..5870fa430 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2573,15 +2573,15 @@ if test X"$want_nghttp2" != Xno; then
+@@ -1331,7 +1331,8 @@ if test X"$OPT_BROTLI" != Xno; then
+ 
+   dnl if given with a prefix, we set -L and -I based on that
+   if test -n "$PREFIX_BROTLI"; then
+-    LIB_BROTLI="-lbrotlidec"
++    # curl-impersonate: Use static libbrotli
++    LIB_BROTLI="-Wl,-Bstatic -lbrotlidec-static -lbrotlicommon-static -Wl,-Bdynamic"
+     LD_BROTLI=-L${PREFIX_BROTLI}/lib$libsuff
+     CPP_BROTLI=-I${PREFIX_BROTLI}/include
+     DIR_BROTLI=${PREFIX_BROTLI}/lib$libsuff
+@@ -1341,7 +1342,11 @@ if test X"$OPT_BROTLI" != Xno; then
+   CPPFLAGS="$CPPFLAGS $CPP_BROTLI"
+   LIBS="$LIB_BROTLI $LIBS"
+ 
+-  AC_CHECK_LIB(brotlidec, BrotliDecoderDecompress)
++  AC_CHECK_LIB(brotlidec, BrotliDecoderDecompress,
++    # curl-impersonate: Define 'action-if-found' explicitly to prevent
++    # -lbrotlidec from being added to LIBS (already added before)
++    AC_DEFINE(HAVE_LIBBROTLI, 1, [Define to 1 if libbrotli exists])
++  )
+ 
+   AC_CHECK_HEADERS(brotli/decode.h,
+     curl_brotli_msg="enabled (libbrotlidec)"
+@@ -2573,15 +2578,15 @@ if test X"$want_nghttp2" != Xno; then
  
    if test "$PKGCONFIG" != "no" ; then
      LIB_H2=`CURL_EXPORT_PCDIR([$want_nghttp2_path])


### PR DESCRIPTION
Compile libbrotli statically into curl-impersonate/libcurl-impersonate
for convenience of usage outside the container.