### PR TITLE
Use a template for generating Dockerfiles

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -15,6 +15,7 @@ WORKDIR /build
 RUN apt-get update && \
     apt-get install -y git ninja-build cmake curl zlib1g-dev
 
+{{#firefox}}
 # Dependencies for building libnss
 # See https://firefox-source-docs.mozilla.org/security/nss/build.html#mozilla-projects-nss-building
 RUN apt-get install -y mercurial python3-pip
@@ -23,7 +24,12 @@ RUN apt-get install -y mercurial python3-pip
 # It loads them from /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so,
 # which is supplied by libnss3 on Debian/Ubuntu
 RUN apt-get install -y libnss3
+{{/firefox}}
 
+{{#chrome}}
+# Dependencies for downloading and building BoringSSL
+RUN apt-get install -y g++ golang-go unzip
+{{/chrome}}
 
 # The following are needed because we are going to change some autoconf scripts,
 # both for libnghttp2 and curl.
@@ -38,6 +44,7 @@ RUN cd brotli-${BROTLI_VERSION} && \
     cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./installed .. && \
     cmake --build . --config Release --target install
 
+{{#firefox}}
 # Needed for building libnss
 RUN pip install gyp-next
 
@@ -50,7 +57,32 @@ RUN curl -o ${NSS_VERSION}.tar.gz ${NSS_URL}
 RUN tar xf ${NSS_VERSION}.tar.gz && \
     cd ${NSS_VERSION}/nss && \
     ./build.sh -o --disable-tests --static
+{{/firefox}}
 
+{{#chrome}}
+# BoringSSL doesn't have versions. Choose a commit that is used in a stable
+# Chromium version.
+ARG BORING_SSL_COMMIT=3a667d10e94186fd503966f5638e134fe9fb4080
+RUN curl -L https://github.com/google/boringssl/archive/${BORING_SSL_COMMIT}.zip -o boringssl.zip && \
+    unzip boringssl && \
+    mv boringssl-${BORING_SSL_COMMIT} boringssl
+
+# Compile BoringSSL.
+# See https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md
+COPY patches/boringssl-*.patch boringssl/
+RUN cd boringssl && \
+    for p in $(ls boringssl-*.patch); do patch -p1 < $p; done && \
+    mkdir build && cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=on -GNinja .. && \
+    ninja
+
+# Fix the directory structure so that curl can compile against it.
+# See https://everything.curl.dev/source/build/tls/boringssl
+RUN mkdir boringssl/build/lib && \
+    ln -s ../crypto/libcrypto.a boringssl/build/lib/libcrypto.a && \
+    ln -s ../ssl/libssl.a boringssl/build/lib/libssl.a && \
+    cp -R boringssl/include boringssl/build
+{{/chrome}}
 
 ARG NGHTTP2_VERSION=nghttp2-1.46.0
 ARG NGHTTP2_URL=https://github.com/nghttp2/nghttp2/releases/download/v1.46.0/nghttp2-1.46.0.tar.bz2
@@ -88,8 +120,15 @@ RUN cd ${CURL_VERSION} && \
                 --disable-shared \
                 --with-nghttp2=/usr/local \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
+{{#firefox}}
                 --with-nss=/build/${NSS_VERSION}/dist/Release \
                 CFLAGS="-I/build/${NSS_VERSION}/dist/public/nss -I/build/${NSS_VERSION}/dist/Release/include/nspr" \
+{{/firefox}}
+{{#chrome}}
+                --with-openssl=/build/boringssl/build \
+                LIBS="-pthread" \
+                CFLAGS="-I/build/boringssl/build" \
+{{/chrome}}
                 USE_CURL_SSLKEYLOGFILE=true && \
     make
 
@@ -101,8 +140,15 @@ RUN mkdir out && \
 RUN cd ${CURL_VERSION} && \
     ./configure --with-nghttp2=/usr/local \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
+{{#firefox}}
                 --with-nss=/build/${NSS_VERSION}/dist/Release \
                 CFLAGS="-I/build/${NSS_VERSION}/dist/public/nss -I/build/${NSS_VERSION}/dist/Release/include/nspr" \
+{{/firefox}}
+{{#chrome}}
+                --with-openssl=/build/boringssl/build \
+                LIBS="-pthread" \
+                CFLAGS="-I/build/boringssl/build" \
+{{/chrome}}
                 USE_CURL_SSLKEYLOGFILE=true && \
     make clean && make
 
@@ -116,5 +162,10 @@ RUN ver=$(readlink -f curl-7.81.0/lib/.libs/libcurl.so | sed 's/.*so\.//') && \
     strip "out/libcurl-impersonate.so.$ver"
 
 # Wrapper scripts
+{{#firefox}}
 COPY curl_ff* out/
+{{/firefox}}
+{{#chrome}}
+COPY curl_chrome* curl_edge* curl_safari* out/
+{{/chrome}}
 RUN chmod +x out/curl_*

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -1,11 +1,23 @@
-# Use same base as the existing Dockerfile
+#
+# NOTE: THIS DOCKERFILE IS GENERATED FROM "Dockerfile.template" VIA
+# "generate-dockerfiles.sh".
+#
+# PLEASE DO NOT EDIT IT DIRECTLY.
+#
+
+# Python is needed for building libnss.
+# Use it as a common base.
 FROM python:3.10.1-slim-buster
 
 WORKDIR /build
 
-# Dependencies for downloading and building BoringSSL
+# Common dependencies
 RUN apt-get update && \
-    apt-get install -y git g++ cmake golang-go ninja-build curl unzip zlib1g-dev
+    apt-get install -y git ninja-build cmake curl zlib1g-dev
+
+
+# Dependencies for downloading and building BoringSSL
+RUN apt-get install -y g++ golang-go unzip
 
 # The following are needed because we are going to change some autoconf scripts,
 # both for libnghttp2 and curl.
@@ -19,6 +31,7 @@ RUN cd brotli-${BROTLI_VERSION} && \
     mkdir build && cd build && \
     cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./installed .. && \
     cmake --build . --config Release --target install
+
 
 # BoringSSL doesn't have versions. Choose a commit that is used in a stable
 # Chromium version.
@@ -72,14 +85,14 @@ RUN cd ${CURL_VERSION} && \
     for p in $(ls curl-*.patch); do patch -p1 < $p; done && \
     autoreconf -fi
 
-# Compile curl with BoringSSL & nghttp2.
+# Compile curl with nghttp2, libbrotli and nss (firefox) or boringssl (chrome).
 # Enable keylogfile for debugging of TLS traffic.
 RUN cd ${CURL_VERSION} && \
     ./configure --enable-static \
                 --disable-shared \
-                --with-openssl=/build/boringssl/build \
                 --with-nghttp2=/usr/local \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
+                --with-openssl=/build/boringssl/build \
                 LIBS="-pthread" \
                 CFLAGS="-I/build/boringssl/build" \
                 USE_CURL_SSLKEYLOGFILE=true && \
@@ -91,9 +104,9 @@ RUN mkdir out && \
 
 # Re-compile libcurl dynamically
 RUN cd ${CURL_VERSION} && \
-    ./configure --with-openssl=/build/boringssl/build \
-                --with-nghttp2=/usr/local \
+    ./configure --with-nghttp2=/usr/local \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
+                --with-openssl=/build/boringssl/build \
                 LIBS="-pthread" \
                 CFLAGS="-I/build/boringssl/build" \
                 USE_CURL_SSLKEYLOGFILE=true && \

--- a/generate_dockerfiles.sh
+++ b/generate_dockerfiles.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+cat <<EOF | mustache - Dockerfile.template > chrome/Dockerfile
+---
+chrome: true
+---
+EOF
+
+cat <<EOF | mustache - Dockerfile.template > firefox/Dockerfile
+---
+firefox: true
+---
+EOF


### PR DESCRIPTION
Since the firefox and chrome builds are similar except for the TLS
library used, it makes sense to unify their Dockerfiles. This commit
introduces a template Dockerfile from which both the build Dockerfiles
are generated using the simple 'mustache' template system.