### PR TITLE
Add Alpine Linux images and push automatically to DockerHub

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -21,7 +21,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (tags, labels) for Docker (chrome)
         id: meta_chrome
         uses: docker/metadata-action@v3
         with:
@@ -30,7 +30,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
           flavor: |
-            suffix=-chrome-alpine3.15
+            suffix=-chrome-alpine
 
       - name: Build and push the Chrome version of curl-impersonate
         uses: docker/build-push-action@v2
@@ -40,3 +40,23 @@ jobs:
           file: chrome/Dockerfile.alpine
           tags: ${{ steps.meta_chrome.outputs.tags }}
           labels: ${{ steps.meta_chrome.outputs.labels }}
+
+      - name: Extract metadata (tags, labels) for Docker (firefox)
+        id: meta_firefox
+        uses: docker/metadata-action@v3
+        with:
+          images: lwthiker/curl-impersonate
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            suffix=-ff-alpine
+
+      - name: Build and push the Firefox version of curl-impersonate
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: firefox/
+          file: firefox/Dockerfile.alpine
+          tags: ${{ steps.meta_firefox.outputs.tags }}
+          labels: ${{ steps.meta_firefox.outputs.labels }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,42 @@
+# Build an Alpine Linux image containing curl-impersonate and push to
+# Docker hub.
+name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  push-docker-image:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta_chrome
+        uses: docker/metadata-action@v3
+        with:
+          images: lwthiker/curl-impersonate
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+          flavor: |
+            suffix=-chrome-alpine3.15
+
+      - name: Build and push the Chrome version of curl-impersonate
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: chrome/
+          file: chrome/Dockerfile.alpine
+          tags: ${{ steps.meta_chrome.outputs.tags }}
+          labels: ${{ steps.meta_chrome.outputs.labels }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -27,10 +27,10 @@ jobs:
         with:
           images: lwthiker/curl-impersonate
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-          flavor: |
-            suffix=-chrome-alpine
+            type=semver,pattern={{version}},suffix=-chrome-alpine
+            type=semver,pattern={{version}},suffix=-chrome
+            type=semver,pattern={{major}}.{{minor}},suffix=-chrome-alpine
+            type=semver,pattern={{major}}.{{minor}},suffix=-chrome
 
       - name: Build and push the Chrome version of curl-impersonate
         uses: docker/build-push-action@v2
@@ -47,10 +47,10 @@ jobs:
         with:
           images: lwthiker/curl-impersonate
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-          flavor: |
-            suffix=-ff-alpine
+            type=semver,pattern={{version}},suffix=-ff-alpine
+            type=semver,pattern={{version}},suffix=-ff
+            type=semver,pattern={{major}}.{{minor}},suffix=-ff-alpine
+            type=semver,pattern={{major}}.{{minor}},suffix=-ff
 
       - name: Build and push the Firefox version of curl-impersonate
         uses: docker/build-push-action@v2

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,35 +5,64 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
+{{#debian}}
 # Python is needed for building libnss.
 # Use it as a common base.
 FROM python:3.10.1-slim-buster
+{{/debian}}
+{{#alpine}}
+FROM alpine:3.15.0 as builder
+{{/alpine}}
 
 WORKDIR /build
 
 # Common dependencies
+{{#debian}}
 RUN apt-get update && \
     apt-get install -y git ninja-build cmake curl zlib1g-dev
+{{/debian}}
+{{#alpine}}
+RUN apk add git build-base make cmake ninja curl zlib-dev patch linux-headers python3 python3-dev
+{{/alpine}}
+
+# The following are needed because we are going to change some autoconf scripts,
+# both for libnghttp2 and curl.
+{{#debian}}
+RUN apt-get install -y autoconf automake autotools-dev pkg-config libtool
+{{/debian}}
+{{#alpine}}
+RUN apk add autoconf automake pkgconfig libtool
+{{/alpine}}
 
 {{#firefox}}
 # Dependencies for building libnss
 # See https://firefox-source-docs.mozilla.org/security/nss/build.html#mozilla-projects-nss-building
+    {{#debian}}
 RUN apt-get install -y mercurial python3-pip
+    {{/debian}}
+    {{#alpine}}
+RUN apk add mercurial py3-pip clang-analyzer
+    {{/alpine}}
 
 # curl tries to load the CA certificates for libnss.
 # It loads them from /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so,
 # which is supplied by libnss3 on Debian/Ubuntu
+    {{#debian}}
 RUN apt-get install -y libnss3
+    {{/debian}}
+    {{#alpine}}
+RUN apk add nss
+    {{/alpine}}
 {{/firefox}}
-
 {{#chrome}}
 # Dependencies for downloading and building BoringSSL
+    {{#debian}}
 RUN apt-get install -y g++ golang-go unzip
+    {{/debian}}
+    {{#alpine}}
+RUN apk add g++ go unzip
+    {{/alpine}}
 {{/chrome}}
-
-# The following are needed because we are going to change some autoconf scripts,
-# both for libnghttp2 and curl.
-RUN apt-get install -y autoconf automake autotools-dev pkg-config libtool
 
 # Download and compile libbrotli
 ARG BROTLI_VERSION=1.0.9
@@ -56,9 +85,12 @@ ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_74_RTM/src/n
 RUN curl -o ${NSS_VERSION}.tar.gz ${NSS_URL}
 RUN tar xf ${NSS_VERSION}.tar.gz && \
     cd ${NSS_VERSION}/nss && \
+{{#alpine}}
+    # Hack to make nss compile on alpine with python3
+    ln -sf python3 /usr/bin/python && \
+{{/alpine}}
     ./build.sh -o --disable-tests --static
 {{/firefox}}
-
 {{#chrome}}
 # BoringSSL doesn't have versions. Choose a commit that is used in a stable
 # Chromium version.
@@ -168,4 +200,22 @@ COPY curl_ff* out/
 {{#chrome}}
 COPY curl_chrome* curl_edge* curl_safari* out/
 {{/chrome}}
+{{#alpine}}
+# Replace /bin/bash with /bin/ash
+RUN sed -i 's@/bin/bash@/bin/ash@' out/curl_*
+{{/alpine}}
 RUN chmod +x out/curl_*
+{{#alpine}}
+
+# When using alpine, create a final, minimal image with the compiled binaries
+# only.
+FROM alpine:3.15.0
+
+# Copy curl-impersonate from the builder image
+COPY --from=builder /build/out/curl-impersonate /usr/local/bin/
+# Wrapper scripts
+COPY --from=builder /build/out/curl_* /usr/local/bin/
+
+# Copy libcurl-impersonate from the builder image
+COPY --from=builder /build/out/libcurl-impersonate.so /usr/local/lib/
+{{/alpine}}

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -44,15 +44,12 @@ RUN apt-get install -y mercurial python3-pip
 RUN apk add mercurial py3-pip clang-analyzer
     {{/alpine}}
 
+    {{#debian}}
 # curl tries to load the CA certificates for libnss.
 # It loads them from /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so,
 # which is supplied by libnss3 on Debian/Ubuntu
-    {{#debian}}
 RUN apt-get install -y libnss3
     {{/debian}}
-    {{#alpine}}
-RUN apk add nss
-    {{/alpine}}
 {{/firefox}}
 {{#chrome}}
 # Dependencies for downloading and building BoringSSL
@@ -210,6 +207,12 @@ RUN chmod +x out/curl_*
 # When using alpine, create a final, minimal image with the compiled binaries
 # only.
 FROM alpine:3.15.0
+{{#firefox}}
+# curl tries to load the CA certificates for libnss.
+# It loads them from /usr/lib/libnssckbi.so,
+# which is supplied by 'nss' on alpine.
+RUN apk add --no-cache nss
+{{/firefox}}
 
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/out/curl-impersonate /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -45,10 +45,29 @@ You can add command line flags and they will be passed on to curl. However, some
 See [Advanced usage](#Advanced-usage) for more options.
 
 ## Installation
-This repository maintains two separate build systems for technical reasons. The **chrome** build is used to impersonate Chrome, Edge and Safari. The **firefox** build is used to impersonate Firefox.
+There are two version of `curl-impersonate` for technical reasons. The **chrome** version is used to impersonate Chrome, Edge and Safari. The **firefox** version is used to impersonate Firefox.
+
+### Docker images
+Docker images based on Alpine Linux with `curl-impersonate` compiled and ready to use are available on [Docker Hub](https://hub.docker.com/repository/docker/lwthiker/curl-impersonate). The images contain the binary and all the wrapper scripts. Use like the following:
+```bash
+# Firefox version
+docker pull lwthiker/curl-impersonate:0.3-ff
+docker run --rm lwthiker/curl-impersonate:0.3-ff curl_ff95 https://www.wikipedia.org
+
+# Chrome version
+docker pull lwthiker/curl-impersonate:0.3-chrome
+docker run --rm lwthiker/curl-impersonate:0.3-chrome curl_chrome99 https://www.wikipedia.org
+```
+
+### Distro packages
+
+AUR packages are available to Arch users: [curl-impersonate-chrome](https://aur.archlinux.org/packages/curl-impersonate-chrome), [curl-impersonate-firefox](https://aur.archlinux.org/packages/curl-impersonate-firefox).
+
+## Building from source
+As mentioned there are two separate build systems. The **chrome** build is used to impersonate Chrome, Edge and Safari. The **firefox** build is used to impersonate Firefox.
 
 ### Chrome build
-[`chrome/Dockerfile`](chrome/Dockerfile) is a Dockerfile that will build curl with all the necessary modifications and patches. Build it like the following:
+[`chrome/Dockerfile`](chrome/Dockerfile) is a debian-based Dockerfile that will build curl with all the necessary modifications and patches. Build it like the following:
 ```
 docker build -t curl-impersonate-chrome chrome/
 ```
@@ -71,10 +90,6 @@ The resulting image contains:
 
 If you use it outside the container, install the following dependency:
 * `sudo apt install libnss3`.  Even though nss is statically compiled into `curl-impersonate`, it is still necessary to install libnss3 because curl dynamically loads `libnssckbi.so`, a file containing Mozilla's list of trusted root certificates. Alternatively, use `curl -k` to disable certificate verification.
-
-### Distro packages
-
-AUR packages are available to Arch users: [curl-impersonate-chrome](https://aur.archlinux.org/packages/curl-impersonate-chrome), [curl-impersonate-firefox](https://aur.archlinux.org/packages/curl-impersonate-firefox).
 
 ## Advanced usage
 ### libcurl-impersonate

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ You can add command line flags and they will be passed on to curl. However, some
 See [Advanced usage](#Advanced-usage) for more options.
 
 ## Installation
-There are two version of `curl-impersonate` for technical reasons. The **chrome** version is used to impersonate Chrome, Edge and Safari. The **firefox** version is used to impersonate Firefox.
+There are two versions of `curl-impersonate` for technical reasons. The **chrome** version is used to impersonate Chrome, Edge and Safari. The **firefox** version is used to impersonate Firefox.
 
 ### Docker images
-Docker images based on Alpine Linux with `curl-impersonate` compiled and ready to use are available on [Docker Hub](https://hub.docker.com/repository/docker/lwthiker/curl-impersonate). The images contain the binary and all the wrapper scripts. Use like the following:
+Docker images based on Alpine Linux with `curl-impersonate` compiled and ready to use are available on [Docker Hub](https://hub.docker.com/r/lwthiker/curl-impersonate). The images contain the binary and all the wrapper scripts. Use like the following:
 ```bash
 # Firefox version
 docker pull lwthiker/curl-impersonate:0.3-ff

--- a/chrome/Dockerfile.alpine
+++ b/chrome/Dockerfile.alpine
@@ -5,22 +5,19 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-# Python is needed for building libnss.
-# Use it as a common base.
-FROM python:3.10.1-slim-buster
+FROM alpine:3.15.0 as builder
 
 WORKDIR /build
 
 # Common dependencies
-RUN apt-get update && \
-    apt-get install -y git ninja-build cmake curl zlib1g-dev
+RUN apk add git build-base make cmake ninja curl zlib-dev patch linux-headers python3 python3-dev
 
 # The following are needed because we are going to change some autoconf scripts,
 # both for libnghttp2 and curl.
-RUN apt-get install -y autoconf automake autotools-dev pkg-config libtool
+RUN apk add autoconf automake pkgconfig libtool
 
 # Dependencies for downloading and building BoringSSL
-RUN apt-get install -y g++ golang-go unzip
+RUN apk add g++ go unzip
 
 # Download and compile libbrotli
 ARG BROTLI_VERSION=1.0.9
@@ -121,4 +118,18 @@ RUN ver=$(readlink -f curl-7.81.0/lib/.libs/libcurl.so | sed 's/.*so\.//') && \
 
 # Wrapper scripts
 COPY curl_chrome* curl_edge* curl_safari* out/
+# Replace /bin/bash with /bin/ash
+RUN sed -i 's@/bin/bash@/bin/ash@' out/curl_*
 RUN chmod +x out/curl_*
+
+# When using alpine, create a final, minimal image with the compiled binaries
+# only.
+FROM alpine:3.15.0
+
+# Copy curl-impersonate from the builder image
+COPY --from=builder /build/out/curl-impersonate /usr/local/bin/
+# Wrapper scripts
+COPY --from=builder /build/out/curl_* /usr/local/bin/
+
+# Copy libcurl-impersonate from the builder image
+COPY --from=builder /build/out/libcurl-impersonate.so /usr/local/lib/

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -15,6 +15,10 @@ WORKDIR /build
 RUN apt-get update && \
     apt-get install -y git ninja-build cmake curl zlib1g-dev
 
+# The following are needed because we are going to change some autoconf scripts,
+# both for libnghttp2 and curl.
+RUN apt-get install -y autoconf automake autotools-dev pkg-config libtool
+
 # Dependencies for building libnss
 # See https://firefox-source-docs.mozilla.org/security/nss/build.html#mozilla-projects-nss-building
 RUN apt-get install -y mercurial python3-pip
@@ -23,11 +27,6 @@ RUN apt-get install -y mercurial python3-pip
 # It loads them from /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so,
 # which is supplied by libnss3 on Debian/Ubuntu
 RUN apt-get install -y libnss3
-
-
-# The following are needed because we are going to change some autoconf scripts,
-# both for libnghttp2 and curl.
-RUN apt-get install -y autoconf automake autotools-dev pkg-config libtool
 
 # Download and compile libbrotli
 ARG BROTLI_VERSION=1.0.9
@@ -50,7 +49,6 @@ RUN curl -o ${NSS_VERSION}.tar.gz ${NSS_URL}
 RUN tar xf ${NSS_VERSION}.tar.gz && \
     cd ${NSS_VERSION}/nss && \
     ./build.sh -o --disable-tests --static
-
 
 ARG NGHTTP2_VERSION=nghttp2-1.46.0
 ARG NGHTTP2_URL=https://github.com/nghttp2/nghttp2/releases/download/v1.46.0/nghttp2-1.46.0.tar.bz2

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -5,22 +5,25 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-# Python is needed for building libnss.
-# Use it as a common base.
-FROM python:3.10.1-slim-buster
+FROM alpine:3.15.0 as builder
 
 WORKDIR /build
 
 # Common dependencies
-RUN apt-get update && \
-    apt-get install -y git ninja-build cmake curl zlib1g-dev
+RUN apk add git build-base make cmake ninja curl zlib-dev patch linux-headers python3 python3-dev
 
 # The following are needed because we are going to change some autoconf scripts,
 # both for libnghttp2 and curl.
-RUN apt-get install -y autoconf automake autotools-dev pkg-config libtool
+RUN apk add autoconf automake pkgconfig libtool
 
-# Dependencies for downloading and building BoringSSL
-RUN apt-get install -y g++ golang-go unzip
+# Dependencies for building libnss
+# See https://firefox-source-docs.mozilla.org/security/nss/build.html#mozilla-projects-nss-building
+RUN apk add mercurial py3-pip clang-analyzer
+
+# curl tries to load the CA certificates for libnss.
+# It loads them from /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so,
+# which is supplied by libnss3 on Debian/Ubuntu
+RUN apk add nss
 
 # Download and compile libbrotli
 ARG BROTLI_VERSION=1.0.9
@@ -31,28 +34,20 @@ RUN cd brotli-${BROTLI_VERSION} && \
     cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./installed .. && \
     cmake --build . --config Release --target install
 
-# BoringSSL doesn't have versions. Choose a commit that is used in a stable
-# Chromium version.
-ARG BORING_SSL_COMMIT=3a667d10e94186fd503966f5638e134fe9fb4080
-RUN curl -L https://github.com/google/boringssl/archive/${BORING_SSL_COMMIT}.zip -o boringssl.zip && \
-    unzip boringssl && \
-    mv boringssl-${BORING_SSL_COMMIT} boringssl
+# Needed for building libnss
+RUN pip install gyp-next
 
-# Compile BoringSSL.
-# See https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md
-COPY patches/boringssl-*.patch boringssl/
-RUN cd boringssl && \
-    for p in $(ls boringssl-*.patch); do patch -p1 < $p; done && \
-    mkdir build && cd build && \
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=on -GNinja .. && \
-    ninja
+ARG NSS_VERSION=nss-3.74
+# This tarball is already bundled with nspr, a dependency of libnss.
+ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_74_RTM/src/nss-3.74-with-nspr-4.32.tar.gz
 
-# Fix the directory structure so that curl can compile against it.
-# See https://everything.curl.dev/source/build/tls/boringssl
-RUN mkdir boringssl/build/lib && \
-    ln -s ../crypto/libcrypto.a boringssl/build/lib/libcrypto.a && \
-    ln -s ../ssl/libssl.a boringssl/build/lib/libssl.a && \
-    cp -R boringssl/include boringssl/build
+# Download and compile nss.
+RUN curl -o ${NSS_VERSION}.tar.gz ${NSS_URL}
+RUN tar xf ${NSS_VERSION}.tar.gz && \
+    cd ${NSS_VERSION}/nss && \
+    # Hack to make nss compile on alpine with python3
+    ln -sf python3 /usr/bin/python && \
+    ./build.sh -o --disable-tests --static
 
 ARG NGHTTP2_VERSION=nghttp2-1.46.0
 ARG NGHTTP2_URL=https://github.com/nghttp2/nghttp2/releases/download/v1.46.0/nghttp2-1.46.0.tar.bz2
@@ -90,9 +85,8 @@ RUN cd ${CURL_VERSION} && \
                 --disable-shared \
                 --with-nghttp2=/usr/local \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
-                --with-openssl=/build/boringssl/build \
-                LIBS="-pthread" \
-                CFLAGS="-I/build/boringssl/build" \
+                --with-nss=/build/${NSS_VERSION}/dist/Release \
+                CFLAGS="-I/build/${NSS_VERSION}/dist/public/nss -I/build/${NSS_VERSION}/dist/Release/include/nspr" \
                 USE_CURL_SSLKEYLOGFILE=true && \
     make
 
@@ -104,9 +98,8 @@ RUN mkdir out && \
 RUN cd ${CURL_VERSION} && \
     ./configure --with-nghttp2=/usr/local \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
-                --with-openssl=/build/boringssl/build \
-                LIBS="-pthread" \
-                CFLAGS="-I/build/boringssl/build" \
+                --with-nss=/build/${NSS_VERSION}/dist/Release \
+                CFLAGS="-I/build/${NSS_VERSION}/dist/public/nss -I/build/${NSS_VERSION}/dist/Release/include/nspr" \
                 USE_CURL_SSLKEYLOGFILE=true && \
     make clean && make
 
@@ -120,5 +113,19 @@ RUN ver=$(readlink -f curl-7.81.0/lib/.libs/libcurl.so | sed 's/.*so\.//') && \
     strip "out/libcurl-impersonate.so.$ver"
 
 # Wrapper scripts
-COPY curl_chrome* curl_edge* curl_safari* out/
+COPY curl_ff* out/
+# Replace /bin/bash with /bin/ash
+RUN sed -i 's@/bin/bash@/bin/ash@' out/curl_*
 RUN chmod +x out/curl_*
+
+# When using alpine, create a final, minimal image with the compiled binaries
+# only.
+FROM alpine:3.15.0
+
+# Copy curl-impersonate from the builder image
+COPY --from=builder /build/out/curl-impersonate /usr/local/bin/
+# Wrapper scripts
+COPY --from=builder /build/out/curl_* /usr/local/bin/
+
+# Copy libcurl-impersonate from the builder image
+COPY --from=builder /build/out/libcurl-impersonate.so /usr/local/lib/

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -20,10 +20,6 @@ RUN apk add autoconf automake pkgconfig libtool
 # See https://firefox-source-docs.mozilla.org/security/nss/build.html#mozilla-projects-nss-building
 RUN apk add mercurial py3-pip clang-analyzer
 
-# curl tries to load the CA certificates for libnss.
-# It loads them from /usr/lib/x86_64-linux-gnu/nss/libnssckbi.so,
-# which is supplied by libnss3 on Debian/Ubuntu
-RUN apk add nss
 
 # Download and compile libbrotli
 ARG BROTLI_VERSION=1.0.9
@@ -121,6 +117,10 @@ RUN chmod +x out/curl_*
 # When using alpine, create a final, minimal image with the compiled binaries
 # only.
 FROM alpine:3.15.0
+# curl tries to load the CA certificates for libnss.
+# It loads them from /usr/lib/libnssckbi.so,
+# which is supplied by 'nss' on alpine.
+RUN apk add --no-cache nss
 
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/out/curl-impersonate /usr/local/bin/

--- a/generate_dockerfiles.sh
+++ b/generate_dockerfiles.sh
@@ -3,11 +3,26 @@
 cat <<EOF | mustache - Dockerfile.template > chrome/Dockerfile
 ---
 chrome: true
+debian: true
+---
+EOF
+cat <<EOF | mustache - Dockerfile.template > chrome/Dockerfile.alpine
+---
+chrome: true
+alpine: true
 ---
 EOF
 
 cat <<EOF | mustache - Dockerfile.template > firefox/Dockerfile
 ---
 firefox: true
+debian: true
+---
+EOF
+
+cat <<EOF | mustache - Dockerfile.template > firefox/Dockerfile.alpine
+---
+firefox: true
+alpine: true
 ---
 EOF

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,7 +2,7 @@ The tests verify that `curl-impersonate` has the same network signature as that 
 
 ## Running the tests
 
-The tests assume that you've built both `curl-impersonate-chrome` and `curl-impersonate-ff` docker images before (see [Installation](https://github.com/lwthiker/curl-impersonate#installation)).
+The tests assume that you've built both `curl-impersonate-chrome` and `curl-impersonate-ff` docker images before (see [Building from source](https://github.com/lwthiker/curl-impersonate#building-from-source)).
 
 To run the tests, build with:
 ```


### PR DESCRIPTION
* Add Dockerfiles to create a minimal Alpine Linux image with curl-impersonate.
* Add GitHub action to automatically build and push these images to Docker Hub.