### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,6 +43,8 @@ sudo make firefox-install
 # Build and install the Chrome version
 make chrome-build
 sudo make chrome-install
+# You may need to update the linker's cache to find libcurl-impersonate
+sudo ldconfig
 # Optionally remove all the build files
 cd ../ && rm -Rf build
 ```


### PR DESCRIPTION
On some systems (Ubuntu), after doing 'make firefox-install' or 'make chrome-install', the linker can't find libcurl-impersonate.
Instruct users to run 'ldconfig' manually after installation to refresh the linker's cache, so it finds libcurl-impersonate in /usr/local/.

Solves #46 