### PR TITLE
Cache build files during GitHub action workflows

### DIFF
--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -116,7 +116,7 @@ jobs:
         id: cache-nss
         uses: actions/cache@v3
         with:
-          path: ${{ env.NSS_VERSION }}/dist/Release
+          path: ${{ env.NSS_VERSION }}/dist
           key: ${{ runner.os }}-nss-build-${{ env.NSS_VERSION }}
 
       # Trick the Makefile into skipping the NSS build step
@@ -125,7 +125,7 @@ jobs:
         if: ${{ steps.cache-nss.outputs.cache-hit != false }}
         run: |
           touch ${{ env.NSS_VERSION }}.tar.gz
-          find ${{ env.NSS_VERSION }}/dist/Release -type f | xargs touch
+          find ${{ env.NSS_VERSION }}/dist -type f | xargs touch
 
       - name: Build the Firefox version of curl-impersonate
         run: |

--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+env:
+  NSS_VERSION: nss-3.75
+  BORING_SSL_COMMIT: 3a667d10e94186fd503966f5638e134fe9fb4080
+
 jobs:
   build-and-test:
     name: Build curl-impersonate and run the tests
@@ -67,11 +71,41 @@ jobs:
           mkdir ${{ runner.temp }}/install
           ./configure --prefix=${{ runner.temp }}/install
 
+      # Cache the build of BoringSSL, which is the longest part of the build
+      # We must cache the .zip as well, otherwise the Makefile will
+      # rebuild BoringSSL.
+      - name: Cache BoringSSL source
+        uses: actions/cache@v3
+        with:
+          path: boringssl.zip
+          key: ${{ runner.os }}-boring-source-${{ env.BORING_SSL_COMMIT }}
+
+      - name: Cache BoringSSL build
+        uses: actions/cache@v3
+        with:
+          path: boringssl/build
+          key: ${{ runner.os }}-boring-build-${{ env.BORING_SSL_COMMIT }}-${{ hashFiles('chrome/patches/boringssl*.patch') }}
+
       - name: Build the Chrome version of curl-impersonate
         run: |
           ${{ matrix.make }} chrome-build
           ${{ matrix.make }} chrome-checkbuild
           ${{ matrix.make }} chrome-install
+
+      # Cache the build of NSS, which is the longest part of the build
+      # We must cache the .tar.gz as well, otherwise the Makefile will
+      # rebuild NSS.
+      - name: Cache NSS source
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.NSS_VERSION }}.tar.gz
+          key: ${{ runner.os }}-nss-source-${{ env.NSS_VERSION }}
+
+      - name: Cache NSS build
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.NSS_VERSION }}/dist/Release
+          key: ${{ runner.os }}-nss-build-${{ env.NSS_VERSION }}
 
       - name: Build the Firefox version of curl-impersonate
         run: |

--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -81,10 +81,19 @@ jobs:
           key: ${{ runner.os }}-boring-source-${{ env.BORING_SSL_COMMIT }}
 
       - name: Cache BoringSSL build
+        id: cache-boringssl
         uses: actions/cache@v3
         with:
           path: boringssl/build
           key: ${{ runner.os }}-boring-build-${{ env.BORING_SSL_COMMIT }}-${{ hashFiles('chrome/patches/boringssl*.patch') }}
+
+      # Trick the Makefile into skipping the BoringSSL build step
+      # if it was found in the cache.
+      - name: Post BoringSSL cache restore
+        if: ${{ steps.cache-boringssl.outputs.cache-hit == true }}
+        run: |
+          touch boringssl.zip
+          find boringssl/build -type f | xargs touch
 
       - name: Build the Chrome version of curl-impersonate
         run: |
@@ -102,10 +111,19 @@ jobs:
           key: ${{ runner.os }}-nss-source-${{ env.NSS_VERSION }}
 
       - name: Cache NSS build
+        id: cache-nss
         uses: actions/cache@v3
         with:
           path: ${{ env.NSS_VERSION }}/dist/Release
           key: ${{ runner.os }}-nss-build-${{ env.NSS_VERSION }}
+
+      # Trick the Makefile into skipping the NSS build step
+      # if it was found in the cache.
+      - name: Post NSS cache restore
+        if: ${{ steps.cache-nss.outputs.cache-hit == true }}
+        run: |
+          touch ${{ env.NSS_VERSION }}.tar.gz
+          find ${{ env.NSS_VERSION }}/dist/Release -type f | xargs touch
 
       - name: Build the Firefox version of curl-impersonate
         run: |

--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -73,7 +73,8 @@ jobs:
 
       # Cache the build of BoringSSL, which is the longest part of the build
       # We must cache the .zip as well, otherwise the Makefile will
-      # rebuild BoringSSL.
+      # rebuild BoringSSL. This whole thing is a bit hacky, but necessary to
+      # reduce the insanely long build times.
       - name: Cache BoringSSL source
         uses: actions/cache@v3
         with:
@@ -88,11 +89,12 @@ jobs:
           key: ${{ runner.os }}-boring-build-${{ env.BORING_SSL_COMMIT }}-${{ hashFiles('chrome/patches/boringssl*.patch') }}
 
       # Trick the Makefile into skipping the BoringSSL build step
-      # if it was found in the cache.
+      # if it was found in the cache. See Makefile.in
       - name: Post BoringSSL cache restore
         if: ${{ steps.cache-boringssl.outputs.cache-hit != false }}
         run: |
           touch boringssl.zip
+          touch boringssl/.patched
           find boringssl/build -type f | xargs touch
 
       - name: Build the Chrome version of curl-impersonate

--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -90,7 +90,7 @@ jobs:
       # Trick the Makefile into skipping the BoringSSL build step
       # if it was found in the cache.
       - name: Post BoringSSL cache restore
-        if: ${{ steps.cache-boringssl.outputs.cache-hit == true }}
+        if: ${{ steps.cache-boringssl.outputs.cache-hit != false }}
         run: |
           touch boringssl.zip
           find boringssl/build -type f | xargs touch
@@ -120,7 +120,7 @@ jobs:
       # Trick the Makefile into skipping the NSS build step
       # if it was found in the cache.
       - name: Post NSS cache restore
-        if: ${{ steps.cache-nss.outputs.cache-hit == true }}
+        if: ${{ steps.cache-nss.outputs.cache-hit != false }}
         run: |
           touch ${{ env.NSS_VERSION }}.tar.gz
           find ${{ env.NSS_VERSION }}/dist/Release -type f | xargs touch

--- a/Makefile.in
+++ b/Makefile.in
@@ -9,8 +9,10 @@ MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 
 BROTLI_VERSION := 1.0.9
+ # In case this is changed, update build-and-test-make.yml as well
 NSS_VERSION := nss-3.75
 NSS_URL := https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_75_RTM/src/nss-3.75-with-nspr-4.32.tar.gz
+ # In case this is changed, update build-and-test-make.yml as well
 BORING_SSL_COMMIT := 3a667d10e94186fd503966f5638e134fe9fb4080
 NGHTTP2_VERSION := nghttp2-1.46.0
 NGHTTP2_URL := https://github.com/nghttp2/nghttp2/releases/download/v1.46.0/nghttp2-1.46.0.tar.bz2


### PR DESCRIPTION
To speed up the automatic workflows, attempt to cache the slowest part
of the build, which is compiling the TLS libraries (NSS/BoringSSL).