### PR TITLE
Add support for impersonating Firefox 100

### DIFF
--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -11,7 +11,7 @@ on:
       - main
 
 env:
-  NSS_VERSION: nss-3.75
+  NSS_VERSION: nss-3.77
   BORING_SSL_COMMIT: 3a667d10e94186fd503966f5638e134fe9fb4080
 
 jobs:

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -74,9 +74,9 @@ RUN cd brotli-${BROTLI_VERSION} && \
 # Needed for building libnss
 RUN pip install gyp-next
 
-ARG NSS_VERSION=nss-3.75
+ARG NSS_VERSION=nss-3.77
 # This tarball is already bundled with nspr, a dependency of libnss.
-ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_75_RTM/src/nss-3.75-with-nspr-4.32.tar.gz
+ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_77_RTM/src/nss-3.77-with-nspr-4.32.tar.gz
 
 # Download and compile nss.
 RUN curl -o ${NSS_VERSION}.tar.gz ${NSS_URL}

--- a/Makefile.in
+++ b/Makefile.in
@@ -10,8 +10,8 @@ MAKEFLAGS += --no-builtin-rules
 
 BROTLI_VERSION := 1.0.9
  # In case this is changed, update build-and-test-make.yml as well
-NSS_VERSION := nss-3.75
-NSS_URL := https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_75_RTM/src/nss-3.75-with-nspr-4.32.tar.gz
+NSS_VERSION := nss-3.77
+NSS_URL := https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_77_RTM/src/nss-3.77-with-nspr-4.32.tar.gz
  # In case this is changed, update build-and-test-make.yml as well
 BORING_SSL_COMMIT := 3a667d10e94186fd503966f5638e134fe9fb4080
 NGHTTP2_VERSION := nghttp2-1.46.0

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following browsers can be impersonated.
 | ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_24x24.png "Firefox") | 91 ESR | 91.6.0esr | Windows 10 | `ff91esr` | [curl_ff91esr](firefox/curl_ff91esr) |
 | ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_24x24.png "Firefox") | 95 | 95.0.2 | Windows 10 | `ff95` | [curl_ff95](firefox/curl_ff95) |
 | ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_24x24.png "Firefox") | 98 | 98.0 | Windows 10 | `ff98` | [curl_ff98](firefox/curl_ff98) |
+| ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_24x24.png "Firefox") | 100 | 100.0 | Windows 10 | `ff100` | [curl_ff98](firefox/curl_ff100) |
 | ![Safari](https://github.com/alrra/browser-logos/blob/main/src/safari/safari_24x24.png "Safari") | 15.3 | 16612.4.9.1.8 | MacOS Big Sur | `safari15_3` | [curl_safari15_3](chrome/curl_safari15_3) |
 
 ## Basic usage

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following browsers can be impersonated.
 | ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_24x24.png "Firefox") | 91 ESR | 91.6.0esr | Windows 10 | `ff91esr` | [curl_ff91esr](firefox/curl_ff91esr) |
 | ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_24x24.png "Firefox") | 95 | 95.0.2 | Windows 10 | `ff95` | [curl_ff95](firefox/curl_ff95) |
 | ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_24x24.png "Firefox") | 98 | 98.0 | Windows 10 | `ff98` | [curl_ff98](firefox/curl_ff98) |
-| ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_24x24.png "Firefox") | 100 | 100.0 | Windows 10 | `ff100` | [curl_ff98](firefox/curl_ff100) |
+| ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_24x24.png "Firefox") | 100 | 100.0 | Windows 10 | `ff100` | [curl_ff100](firefox/curl_ff100) |
 | ![Safari](https://github.com/alrra/browser-logos/blob/main/src/safari/safari_24x24.png "Safari") | 15.3 | 16612.4.9.1.8 | MacOS Big Sur | `safari15_3` | [curl_safari15_3](chrome/curl_safari15_3) |
 
 ## Basic usage

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -40,9 +40,9 @@ RUN cd brotli-${BROTLI_VERSION} && \
 # Needed for building libnss
 RUN pip install gyp-next
 
-ARG NSS_VERSION=nss-3.75
+ARG NSS_VERSION=nss-3.77
 # This tarball is already bundled with nspr, a dependency of libnss.
-ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_75_RTM/src/nss-3.75-with-nspr-4.32.tar.gz
+ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_77_RTM/src/nss-3.77-with-nspr-4.32.tar.gz
 
 # Download and compile nss.
 RUN curl -o ${NSS_VERSION}.tar.gz ${NSS_URL}

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -33,9 +33,9 @@ RUN cd brotli-${BROTLI_VERSION} && \
 # Needed for building libnss
 RUN pip install gyp-next
 
-ARG NSS_VERSION=nss-3.75
+ARG NSS_VERSION=nss-3.77
 # This tarball is already bundled with nspr, a dependency of libnss.
-ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_75_RTM/src/nss-3.75-with-nspr-4.32.tar.gz
+ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_77_RTM/src/nss-3.77-with-nspr-4.32.tar.gz
 
 # Download and compile nss.
 RUN curl -o ${NSS_VERSION}.tar.gz ${NSS_URL}

--- a/firefox/curl_ff100
+++ b/firefox/curl_ff100
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Find the directory of this script
+dir=`echo "$0" | sed 's%/[^/]*$%%'`
+
+# The list of ciphers can be obtained by looking at the Client Hello message in
+# Wireshark, then converting it using the cipherlist array at
+# https://github.com/curl/curl/blob/master/lib/vtls/nss.c
+"$dir/curl-impersonate-ff" \
+    --ciphers aes_128_gcm_sha_256,chacha20_poly1305_sha_256,aes_256_gcm_sha_384,ecdhe_ecdsa_aes_128_gcm_sha_256,ecdhe_rsa_aes_128_gcm_sha_256,ecdhe_ecdsa_chacha20_poly1305_sha_256,ecdhe_rsa_chacha20_poly1305_sha_256,ecdhe_ecdsa_aes_256_gcm_sha_384,ecdhe_rsa_aes_256_gcm_sha_384,ecdhe_ecdsa_aes_256_sha,ecdhe_ecdsa_aes_128_sha,ecdhe_rsa_aes_128_sha,ecdhe_rsa_aes_256_sha,rsa_aes_128_gcm_sha_256,rsa_aes_256_gcm_sha_384,rsa_aes_128_sha,rsa_aes_256_sha \
+    -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0' \
+    -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' \
+    -H 'Accept-Language: en-US,en;q=0.5' \
+    -H 'Accept-Encoding: gzip, deflate, br' \
+    -H 'Upgrade-Insecure-Requests: 1' \
+    -H 'Sec-Fetch-Dest: document' \
+    -H 'Sec-Fetch-Mode: navigate' \
+    -H 'Sec-Fetch-Site: none' \
+    -H 'Sec-Fetch-User: ?1' \
+    -H 'TE: Trailers' \
+    --http2 --false-start --compressed \
+    "$@"

--- a/firefox/patches/curl-impersonate.patch
+++ b/firefox/patches/curl-impersonate.patch
@@ -216,7 +216,7 @@ index 769363941..6e2f1b829 100644
  
  CHECKSRC = $(CS_$(V))
 diff --git a/lib/easy.c b/lib/easy.c
-index 20293a710..f08403bc0 100644
+index 20293a710..87acdb814 100644
 --- a/lib/easy.c
 +++ b/lib/easy.c
 @@ -80,6 +80,7 @@
@@ -227,7 +227,7 @@ index 20293a710..f08403bc0 100644
  
  /* The last 3 #include files should be in this order */
  #include "curl_printf.h"
-@@ -282,6 +283,202 @@ void curl_global_cleanup(void)
+@@ -282,6 +283,237 @@ void curl_global_cleanup(void)
    init_flags  = 0;
  }
  
@@ -351,6 +351,41 @@ index 20293a710..f08403bc0 100644
 +      "Sec-Fetch-User: ?1",
 +      "TE: Trailers"
 +    }
++  },
++  {
++    .target = "ff100",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++      "aes_128_gcm_sha_256,"
++      "chacha20_poly1305_sha_256,"
++      "aes_256_gcm_sha_384,"
++      "ecdhe_ecdsa_aes_128_gcm_sha_256,"
++      "ecdhe_rsa_aes_128_gcm_sha_256,"
++      "ecdhe_ecdsa_chacha20_poly1305_sha_256,"
++      "ecdhe_rsa_chacha20_poly1305_sha_256,"
++      "ecdhe_ecdsa_aes_256_gcm_sha_384,"
++      "ecdhe_rsa_aes_256_gcm_sha_384,"
++      "ecdhe_ecdsa_aes_256_sha,"
++      "ecdhe_ecdsa_aes_128_sha,"
++      "ecdhe_rsa_aes_128_sha,"
++      "ecdhe_rsa_aes_256_sha,"
++      "rsa_aes_128_gcm_sha_256,"
++      "rsa_aes_256_gcm_sha_384,"
++      "rsa_aes_128_sha,"
++      "rsa_aes_256_sha",
++    .http_headers = {
++      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
++      "Accept-Language: en-US,en;q=0.5",
++      "Accept-Encoding: gzip, deflate, br",
++      "Upgrade-Insecure-Requests: 1",
++      "Sec-Fetch-Dest: document",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-User: ?1",
++      "TE: Trailers"
++    }
 +  }
 +};
 +
@@ -430,7 +465,7 @@ index 20293a710..f08403bc0 100644
  /*
   * curl_easy_init() is the external interface to alloc, setup and init an
   * easy handle that is returned. If anything goes wrong, NULL is returned.
-@@ -290,6 +487,7 @@ struct Curl_easy *curl_easy_init(void)
+@@ -290,6 +522,7 @@ struct Curl_easy *curl_easy_init(void)
  {
    CURLcode result;
    struct Curl_easy *data;
@@ -438,7 +473,7 @@ index 20293a710..f08403bc0 100644
  
    /* Make sure we inited the global SSL stuff */
    if(!initialized) {
-@@ -308,6 +506,22 @@ struct Curl_easy *curl_easy_init(void)
+@@ -308,6 +541,22 @@ struct Curl_easy *curl_easy_init(void)
      return NULL;
    }
  
@@ -461,7 +496,7 @@ index 20293a710..f08403bc0 100644
    return data;
  }
  
-@@ -878,6 +1092,13 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
+@@ -878,6 +1127,13 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
      outcurl->state.referer_alloc = TRUE;
    }
  

--- a/tests/signatures.yaml
+++ b/tests/signatures.yaml
@@ -751,6 +751,94 @@ signature:
             - 'sec-fetch-user: ?1'
             - 'te: trailers'
 ---
+name: firefox_100.0_win10
+browser:
+    name: firefox
+    version: 100.0
+    os: win10
+    mode: regular
+signature:
+    tls_client_hello:
+        record_version: 'TLS_VERSION_1_0'
+        handshake_version: 'TLS_VERSION_1_2'
+        session_id_length: 32
+        ciphersuites: [
+            0x1301, 0x1303, 0x1302, 0xc02b, 0xc02f, 0xcca9, 0xcca8, 0xc02c,
+            0xc030, 0xc00a, 0xc009, 0xc013, 0xc014, 0x009c, 0x009d, 0x002f,
+            0x0035
+        ]
+        comp_methods: [0x00]
+        extensions:
+            - type: server_name
+            - type: extended_master_secret
+              length: 0
+            - type: renegotiation_info
+              length: 1
+            - type: supported_groups
+              length: 14
+              supported_groups: [
+                  0x1d, 0x017, 0x18, 0x19, 0x0100, 0x0101
+              ]
+            - type: ec_point_formats
+              length: 2
+              ec_point_formats: [0]
+            - type: session_ticket
+              length: 0
+            - type: application_layer_protocol_negotiation
+              length: 14
+              alpn_list: ['h2', 'http/1.1']
+            - type: status_request
+              length: 5
+              status_request_type: 0x01
+            - type: delegated_credentials
+              length: 10
+              sig_hash_algs: [
+                  0x0403, 0x0503, 0x0603, 0x0203
+              ]
+            - type: keyshare
+              length: 107
+              key_shares:
+                  - group: 29
+                    length: 32
+                  - group: 23
+                    length: 65
+            - type: supported_versions
+              length: 5
+              supported_versions: [
+                  'TLS_VERSION_1_3', 'TLS_VERSION_1_2'
+              ]
+            - type: signature_algorithms
+              length: 24
+              sig_hash_algs: [
+                  0x0403, 0x0503, 0x0603, 0x0804,
+                  0x0805, 0x0806, 0x0401, 0x0501,
+                  0x0601, 0x0203, 0x0201
+              ]
+            - type: psk_key_exchange_modes
+              length: 2
+              psk_ke_mode: 1
+            - type: record_size_limit
+              length: 2
+              record_size_limit: 16385
+            - type: padding
+    http2:
+        pseudo_headers:
+            - ':method'
+            - ':path'
+            - ':authority'
+            - ':scheme'
+        headers:
+            - 'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0'
+            - 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8'
+            - 'accept-language: en-US,en;q=0.5'
+            - 'accept-encoding: gzip, deflate, br'
+            - 'upgrade-insecure-requests: 1'
+            - 'sec-fetch-dest: document'
+            - 'sec-fetch-mode: navigate'
+            - 'sec-fetch-site: none'
+            - 'sec-fetch-user: ?1'
+            - 'te: trailers'
+---
 name: safari_15.3_macos11.6.4
 browser:
     name: safari

--- a/tests/test_impersonate.py
+++ b/tests/test_impersonate.py
@@ -138,6 +138,7 @@ class TestImpersonation:
         ("curl_ff91esr", None, None, "firefox_91.6.0esr_win10"),
         ("curl_ff95", None, None, "firefox_95.0.2_win10"),
         ("curl_ff98", None, None, "firefox_98.0_win10"),
+        ("curl_ff100", None, None, "firefox_100.0_win10"),
 
         # Test libcurl-impersonate by loading it with LD_PRELOAD to an app
         # linked against the regular libcurl and setting the
@@ -213,6 +214,14 @@ class TestImpersonation:
             },
             "libcurl-impersonate-ff",
             "firefox_98.0_win10"
+        ),
+        (
+            "minicurl",
+            {
+                "CURL_IMPERSONATE": "ff100"
+            },
+            "libcurl-impersonate-ff",
+            "firefox_100.0_win10"
         )
     ]
 


### PR DESCRIPTION
Add support for impersonating Firefox 100. The TLS signature is identical to
previous versions of Firefox.

In addition, upgrade NSS (Firefox's TLS library) to version 3.77 used by
Firefox 100. This is not strictly necessary as the previous version used
works just fine, but it's better keep up with the newest version.