### PR TITLE
Fix build system to work on Red Hat-based systems

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -69,7 +69,8 @@ curl-impersonate-chrome https://www.wikipedia.org
 Install dependencies:
 ```
 yum groupinstall "Development Tools"
-yum install cmake cmake3 python3 python3-pip
+yum groupinstall "C Development Tools and Libraries" # Fedora only
+yum install cmake3 python3 python3-pip
 # Install Ninja. This may depend on your system.
 yum install ninja-build
 # OR

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ There are two versions of `curl-impersonate` for technical reasons. The **chrome
 
 ## Native build
 
-### Linux (Ubuntu)
+### Ubuntu
 
 Install dependencies for building all the components:
 ```
@@ -63,6 +63,32 @@ or run directly with you own flags:
 curl-impersonate-ff https://www.wikipedia.org
 curl-impersonate-chrome https://www.wikipedia.org
 ```
+
+### Red Hat based (CentOS/Fedora/Amazon Linux)
+
+Install dependencies:
+```
+yum groupinstall "Development Tools"
+yum install cmake cmake3 python3 python3-pip
+# Install Ninja. This may depend on your system.
+yum install ninja-build
+# OR
+pip3 install ninja
+```
+
+For the Firefox version, install NSS and gyp:
+```
+yum install nss nss-pem
+pip3 install gyp-next
+```
+
+For the Chrome version, install Go.
+You may need to follow the [Go installation instructions](https://go.dev/doc/install) if it's not packaged for your system:
+```
+yum install golang
+```
+
+Then follow the 'Ubuntu' instructions for the actual build.
 
 ### macOS
 Install dependencies for building all the components:

--- a/Makefile.in
+++ b/Makefile.in
@@ -3,7 +3,7 @@
 
 SHELL := bash
 .ONESHELL:
-.SHELLFLAGS := -eu -o pipefail -c
+.SHELLFLAGS := -euc
 .DELETE_ON_ERROR:
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
@@ -150,8 +150,11 @@ $(brotli_static_libs): brotli-$(BROTLI_VERSION).tar.gz
 	cd brotli-$(BROTLI_VERSION)
 	mkdir -p out
 	cd out
-	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./installed ..
-	cmake --build . --config Release --target install
+	@cmake@ -DCMAKE_BUILD_TYPE=Release \
+			-DCMAKE_INSTALL_PREFIX=./installed \
+			-DCMAKE_INSTALL_LIBDIR=lib \
+			..
+	@cmake@ --build . --config Release --target install
 
 
 $(NSS_VERSION).tar.gz:
@@ -181,8 +184,8 @@ boringssl/.patched: $(srcdir)/chrome/patches/boringssl-*.patch
 $(boringssl_static_libs): boringssl.zip boringssl/.patched
 	mkdir -p $(boringssl_install_dir)
 	cd $(boringssl_install_dir)
-	cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=on -GNinja ..
-	ninja
+	@cmake@ -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=on -GNinja ..
+	@ninja@
 	# Fix the directory structure so that curl can compile against it.
 	# See https://everything.curl.dev/source/build/tls/boringssl
 	mkdir -p lib
@@ -197,7 +200,10 @@ $(NGHTTP2_VERSION).tar.bz2:
 $(nghttp2_static_libs): $(NGHTTP2_VERSION).tar.bz2
 	tar -xf $(NGHTTP2_VERSION).tar.bz2
 	cd $(NGHTTP2_VERSION)
-	./configure --prefix=$(nghttp2_install_dir) --with-pic --disable-shared
+	./configure --prefix=$(nghttp2_install_dir) \
+				--with-pic \
+				--disable-shared \
+				--disable-python-bindings
 	$(MAKE) MAKEFLAGS=
 	$(MAKE) install MAKEFLAGS=
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -184,7 +184,13 @@ boringssl/.patched: $(srcdir)/chrome/patches/boringssl-*.patch
 $(boringssl_static_libs): boringssl.zip boringssl/.patched
 	mkdir -p $(boringssl_install_dir)
 	cd $(boringssl_install_dir)
-	@cmake@ -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=on -GNinja ..
+	# The extra CMAKE_C_FLAGS are needed because otherwise boringssl fails to
+	# compile in release mode on some systems with gcc 12 (e.g. Fedora).
+	@cmake@ -DCMAKE_BUILD_TYPE=Release \
+			-DCMAKE_POSITION_INDEPENDENT_CODE=on \
+			-DCMAKE_C_FLAGS="-Wno-stringop-overflow -Wno-array-bounds" \
+			-GNinja \
+			..
 	@ninja@
 	# Fix the directory structure so that curl can compile against it.
 	# See https://everything.curl.dev/source/build/tls/boringssl

--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,12 @@ AC_ARG_ENABLE([static],
     [AC_SUBST([curl_configure_options], ["--enable-static --disable-shared"])],
     [])
 
+# BoringSSL requires cmake 3.5+, which is sometimes available under
+# "cmake3" instead of "cmake"
+AC_CHECK_PROGS([cmake], [cmake3 cmake])
+
+AC_CHECK_PROGS([ninja], [ninja ninja-build])
+
 AC_CONFIG_FILES([Makefile])
 
 AC_OUTPUT


### PR DESCRIPTION
Tweak the curl-impersonate build system to make it work on Red Hat
based systems such as CentOS, Fedora and Amazon Linux.

* Change the Makefile to be more portable with different bash versions.
* Detect whether cmake is 'cmake' or 'cmake3', and whether ninja is
'ninja' or 'ninja-build'.
* Explicitly tell brotli to put its libraries in 'lib' dir, otherwise it
might put them in 'lib64' where curl doesn't find them.
* Add instructions for building curl-impersonate from source on Red Hat
based systems.