### PR TITLE
Add unzip to dependencies for make chrome-build

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ sudo apt install python3-pip libnss3
 pip install gyp-next
 export PATH="$PATH:~/.local/bin" # Add gyp to PATH
 # For the Chrome version only
-sudo apt install golang-go
+sudo apt install golang-go unzip
 ```
 
 Clone this repository:


### PR DESCRIPTION
On a very minimal Debian 10 (buster) install, I did not have the `unzip` command line tool installed, so the `make chrome-build` could not extract boringssl. This updates the documentation to also suggest `apt install unzip`