### PR TITLE
Upload precompiled libcurl impersonate on release

### DIFF
--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -149,9 +149,16 @@ jobs:
           python_bin=$(which python3)
           sudo $python_bin -m pytest . --log-cli-level DEBUG --install-dir ${{ runner.temp }}/install --capture-interface ${{ matrix.capture_interface }}
 
-       # If it's a tag, create a release and upload the binaries.
-       # For that we recompile curl-impersonate statically.
-      - name: Recompile statically for release assets
+       # Upload pre-compiled binaries to GitHub releases page.
+      - name: Create tar release files for libcurl-impersonate
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+            cd ${{ runner.temp }}/install/lib
+            tar -c -z -f ${{ runner.temp }}/libcurl-impersonate-${{ github.ref_name }}.${{ matrix.release_name }}.tar.gz libcurl-impersonate*
+            echo "release_file_lib=${{ runner.temp }}/libcurl-impersonate-${{ github.ref_name }}.${{ matrix.release_name }}.tar.gz" >> $GITHUB_ENV
+
+       # Recompile curl-impersonate statically.
+      - name: Recompile statically
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           ${{ matrix.make }} chrome-clean
@@ -166,15 +173,17 @@ jobs:
           ${{ matrix.make }} firefox-checkbuild
           ${{ matrix.make }} firefox-install-strip
 
-      - name: Create tar release files
+      - name: Create tar release files for curl-impersonate
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           cd ${{ runner.temp }}/install/bin
           tar -c -z -f ${{ runner.temp }}/curl-impersonate-${{ github.ref_name }}.${{ matrix.release_name }}.tar.gz curl-impersonate-ff curl-impersonate-chrome curl_*
-          echo "release_file=${{ runner.temp }}/curl-impersonate-${{ github.ref_name }}.${{ matrix.release_name }}.tar.gz" >> $GITHUB_ENV
+          echo "release_file_bin=${{ runner.temp }}/curl-impersonate-${{ github.ref_name }}.${{ matrix.release_name }}.tar.gz" >> $GITHUB_ENV
 
       - name: Upload release files
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: ${{ env.release_file }}
+          files: |
+              ${{ env.release_file_lib }}
+              ${{ env.release_file_bin }}

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Pre-compiled binaries for Linux and macOS (Intel) are available at the [GitHub r
 * Red Hat/Fedora/CentOS - `yum install nss nss-pem`
 * macOS - `brew install nss`
 
-The pre-compiled binaries are statically compiled with libcurl(-impersonate) for ease of use. If you wish to use libcurl-impersonate, please build from source.
+The pre-compiled binaries contain libcurl-impersonate and a statically compiled curl-impersonate for ease of use.
 
 ### Building from source
 See [INSTALL.md](INSTALL.md).


### PR DESCRIPTION
Upload a tar file with libcurl-impersonate compiled for Ubuntu and macOS
automatically for each GitHub release. Previously only a statically
compiled version of the binary curl-impersonate was uploaded.