### PR TITLE
Portable shebangs for better compatibility

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -219,8 +219,8 @@ COPY curl_ff* out/
 COPY curl_chrome* curl_edge* curl_safari* out/
 {{/chrome}}
 {{#alpine}}
-# Replace /bin/bash with /bin/ash
-RUN sed -i 's@/bin/bash@/bin/ash@' out/curl_*
+# Replace /usr/bin/env bash with /usr/bin/env ash
+RUN sed -i 's@/usr/bin/env bash@/usr/bin/env ash@' out/curl_*
 {{/alpine}}
 RUN chmod +x out/curl_*
 {{#alpine}}

--- a/chrome/Dockerfile.alpine
+++ b/chrome/Dockerfile.alpine
@@ -130,8 +130,8 @@ RUN ! (ldd ./out/curl-impersonate | grep -q -e nghttp2 -e brotli -e ssl -e crypt
 
 # Wrapper scripts
 COPY curl_chrome* curl_edge* curl_safari* out/
-# Replace /bin/bash with /bin/ash
-RUN sed -i 's@/bin/bash@/bin/ash@' out/curl_*
+# Replace /usr/bin/env bash with /usr/bin/env ash
+RUN sed -i 's@/usr/bin/env bash@/usr/bin/env ash@' out/curl_*
 RUN chmod +x out/curl_*
 
 # When using alpine, create a final, minimal image with the compiled binaries

--- a/chrome/curl_chrome100
+++ b/chrome/curl_chrome100
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find the directory of this script
 dir=${0%/*}

--- a/chrome/curl_chrome101
+++ b/chrome/curl_chrome101
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find the directory of this script
 dir=${0%/*}

--- a/chrome/curl_chrome99
+++ b/chrome/curl_chrome99
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find the directory of this script
 dir=${0%/*}

--- a/chrome/curl_chrome99_android
+++ b/chrome/curl_chrome99_android
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find the directory of this script
 dir=${0%/*}

--- a/chrome/curl_edge101
+++ b/chrome/curl_edge101
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find the directory of this script
 dir=${0%/*}

--- a/chrome/curl_edge99
+++ b/chrome/curl_edge99
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find the directory of this script
 dir=${0%/*}

--- a/chrome/curl_safari15_3
+++ b/chrome/curl_safari15_3
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find the directory of this script
 dir=${0%/*}

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -120,8 +120,8 @@ RUN ! (ldd ./out/curl-impersonate | grep -q -e nghttp2 -e brotli -e ssl -e crypt
 
 # Wrapper scripts
 COPY curl_ff* out/
-# Replace /bin/bash with /bin/ash
-RUN sed -i 's@/bin/bash@/bin/ash@' out/curl_*
+# Replace /usr/bin/env bash with /usr/bin/env ash
+RUN sed -i 's@/usr/bin/env bash@/usr/bin/env ash@' out/curl_*
 RUN chmod +x out/curl_*
 
 # When using alpine, create a final, minimal image with the compiled binaries

--- a/firefox/curl_ff100
+++ b/firefox/curl_ff100
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find the directory of this script
 dir=${0%/*}

--- a/firefox/curl_ff91esr
+++ b/firefox/curl_ff91esr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find the directory of this script
 dir=${0%/*}

--- a/firefox/curl_ff95
+++ b/firefox/curl_ff95
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find the directory of this script
 dir=${0%/*}

--- a/firefox/curl_ff98
+++ b/firefox/curl_ff98
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find the directory of this script
 dir=${0%/*}


### PR DESCRIPTION
This is the recommended approach and it's necessary on systems like NixOS.

See: https://web.archive.org/web/20220617225709/https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my