### PR TITLE
Push Debian-based Docker images to DockerHub

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -21,8 +21,8 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Extract metadata (tags, labels) for Docker (chrome)
-        id: meta_chrome
+      - name: Extract metadata (tags, labels) for Docker (chrome, alpine)
+        id: meta_chrome_alpine
         uses: docker/metadata-action@v3
         with:
           images: lwthiker/curl-impersonate
@@ -38,11 +38,11 @@ jobs:
           push: true
           context: chrome/
           file: chrome/Dockerfile.alpine
-          tags: ${{ steps.meta_chrome.outputs.tags }}
-          labels: ${{ steps.meta_chrome.outputs.labels }}
+          tags: ${{ steps.meta_chrome_alpine.outputs.tags }}
+          labels: ${{ steps.meta_chrome_alpine.outputs.labels }}
 
-      - name: Extract metadata (tags, labels) for Docker (firefox)
-        id: meta_firefox
+      - name: Extract metadata (tags, labels) for Docker (firefox, alpine)
+        id: meta_ff_alpine
         uses: docker/metadata-action@v3
         with:
           images: lwthiker/curl-impersonate
@@ -58,5 +58,41 @@ jobs:
           push: true
           context: firefox/
           file: firefox/Dockerfile.alpine
-          tags: ${{ steps.meta_firefox.outputs.tags }}
-          labels: ${{ steps.meta_firefox.outputs.labels }}
+          tags: ${{ steps.meta_ff_alpine.outputs.tags }}
+          labels: ${{ steps.meta_ff_alpine.outputs.labels }}
+
+      - name: Extract metadata (tags, labels) for Docker (chrome, debian)
+        id: meta_chrome_debian
+        uses: docker/metadata-action@v3
+        with:
+          images: lwthiker/curl-impersonate
+          tags: |
+            type=semver,pattern={{version}},suffix=-chrome-slim-buster
+            type=semver,pattern={{major}}.{{minor}},suffix=-chrome-slim-buster
+
+      - name: Build and push the Chrome version of curl-impersonate
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: chrome/
+          file: chrome/Dockerfile
+          tags: ${{ steps.meta_chrome_debian.outputs.tags }}
+          labels: ${{ steps.meta_chrome_debian.outputs.labels }}
+
+      - name: Extract metadata (tags, labels) for Docker (firefox, debian)
+        id: meta_ff_debian
+        uses: docker/metadata-action@v3
+        with:
+          images: lwthiker/curl-impersonate
+          tags: |
+            type=semver,pattern={{version}},suffix=-ff-slim-buster
+            type=semver,pattern={{major}}.{{minor}},suffix=-ff-slim-buster
+
+      - name: Build and push the Firefox version of curl-impersonate
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: firefox/
+          file: firefox/Dockerfile
+          tags: ${{ steps.meta_ff_debian.outputs.tags }}
+          labels: ${{ steps.meta_ff_debian.outputs.labels }}

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -249,6 +249,8 @@ RUN apt-get update && apt-get install -y libnss3 nss-plugin-pem
 
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
+# Update the loader's cache
+RUN ldconfig
 {{#debian}}
 # Copy to /build/out as well for backward compatibility with previous versions.
 COPY --from=builder /build/out /build/out

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -8,7 +8,7 @@
 {{#debian}}
 # Python is needed for building libnss.
 # Use it as a common base.
-FROM python:3.10.1-slim-buster
+FROM python:3.10.1-slim-buster as builder
 {{/debian}}
 {{#alpine}}
 FROM alpine:3.15.0 as builder
@@ -225,10 +225,10 @@ COPY curl_chrome* curl_edge* curl_safari* out/
 RUN sed -i 's@/usr/bin/env bash@/usr/bin/env ash@' out/curl_*
 {{/alpine}}
 RUN chmod +x out/curl_*
-{{#alpine}}
 
-# When using alpine, create a final, minimal image with the compiled binaries
+# Create a final, minimal image with the compiled binaries
 # only.
+{{#alpine}}
 FROM alpine:3.15.0
 {{#firefox}}
 # curl tries to load the CA certificates for libnss.
@@ -236,9 +236,22 @@ FROM alpine:3.15.0
 # which is supplied by 'nss' on alpine.
 RUN apk add --no-cache nss
 {{/firefox}}
+{{/alpine}}
+{{#debian}}
+FROM debian:buster-slim
+{{#firefox}}
+# curl tries to load the CA certificates for libnss.
+# It loads them from /usr/lib/libnssckbi.so and /usr/lib/libnsspem.so,
+# which are supplied by 'libnss3' and 'nss-plugin-pem' on debian.
+RUN apt-get update && apt-get install -y libnss3 nss-plugin-pem
+{{/firefox}}
+{{/debian}}
 
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
+{{#debian}}
+# Copy to /build/out as well for backward compatibility with previous versions.
+COPY --from=builder /build/out /build/out
+{{/debian}}
 # Wrapper scripts
 COPY --from=builder /build/out/curl_* /usr/local/bin/
-{{/alpine}}

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -239,14 +239,14 @@ RUN apk add --no-cache nss
 {{/alpine}}
 {{#debian}}
 FROM debian:buster-slim
+RUN apt-get update && apt-get install -y ca-certificates
 {{#firefox}}
 # curl tries to load the CA certificates for libnss.
 # It loads them from /usr/lib/libnssckbi.so and /usr/lib/libnsspem.so,
 # which are supplied by 'libnss3' and 'nss-plugin-pem' on debian.
-RUN apt-get update && apt-get install -y libnss3 nss-plugin-pem
+RUN apt-get install -y libnss3 nss-plugin-pem
 {{/firefox}}
 {{/debian}}
-
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
 {{#debian}}

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -249,9 +249,9 @@ RUN apt-get update && apt-get install -y libnss3 nss-plugin-pem
 
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
+{{#debian}}
 # Update the loader's cache
 RUN ldconfig
-{{#debian}}
 # Copy to /build/out as well for backward compatibility with previous versions.
 COPY --from=builder /build/out /build/out
 {{/debian}}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -160,9 +160,9 @@ The Docker build is a bit more reproducible and serves as the reference implemen
 ```
 docker build -t curl-impersonate-chrome chrome/
 ```
-The resulting image contains a `/build/out` directory with the following:
+The resulting binaries and libraries are in the `/usr/local` directory, which contains:
 * `curl-impersonate-chrome`, `curl-impersonate` - The curl binary that can impersonate Chrome/Edge/Safari. It is compiled statically against libcurl, BoringSSL, and libnghttp2 so that it won't conflict with any existing libraries on your system. You can use it from the container or copy it out. Tested to work on Ubuntu 20.04.
-* `curl_chrome98`, `curl_chrome99`, `...` - Wrapper scripts that launch `curl-impersonate` with all the needed flags.
+* `curl_chrome99`, `curl_chrome100`, `...` - Wrapper scripts that launch `curl-impersonate` with all the needed flags.
 * `libcurl-impersonate-chrome.so`, `libcurl-impersonate.so` - libcurl compiled with impersonation support. See [libcurl-impersonate](#libcurl-impersonate) below for more details.
 
 You can use them inside the docker, copy them out using `docker cp` or use them in a multi-stage docker build.
@@ -172,7 +172,7 @@ Build with:
 ```
 docker build -t curl-impersonate-ff firefox/
 ```
-The resulting image contains a `/build/out` directory with the following:
+The resulting binaries and libraries are in the `/usr/local` directory, which contains:
 * `curl-impersonate-ff`, `curl-impersonate` - The curl binary that can impersonate Firefox. It is compiled statically against libcurl, nss, and libnghttp2 so that it won't conflict with any existing libraries on your system. You can use it from the container or copy it out. Tested to work on Ubuntu 20.04.
 * `curl_ff91esr`, `curl_ff95`, `...` - Wrapper scripts that launch `curl-impersonate` with all the needed flags.
 * `libcurl-impersonate-ff.so`, `libcurl-impersonate.so` - libcurl compiled with impersonation support. See [libcurl-impersonate](#libcurl-impersonate) below for more details.

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -7,7 +7,7 @@
 
 # Python is needed for building libnss.
 # Use it as a common base.
-FROM python:3.10.1-slim-buster
+FROM python:3.10.1-slim-buster as builder
 
 WORKDIR /build
 
@@ -134,3 +134,14 @@ RUN ! (ldd ./out/curl-impersonate | grep -q -e nghttp2 -e brotli -e ssl -e crypt
 # Wrapper scripts
 COPY curl_chrome* curl_edge* curl_safari* out/
 RUN chmod +x out/curl_*
+
+# Create a final, minimal image with the compiled binaries
+# only.
+FROM debian:buster-slim
+
+# Copy curl-impersonate from the builder image
+COPY --from=builder /build/install /usr/local
+# Copy to /build/out as well for backward compatibility with previous versions.
+COPY --from=builder /build/out /build/out
+# Wrapper scripts
+COPY --from=builder /build/out/curl_* /usr/local/bin/

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -138,7 +138,7 @@ RUN chmod +x out/curl_*
 # Create a final, minimal image with the compiled binaries
 # only.
 FROM debian:buster-slim
-
+RUN apt-get update && apt-get install -y ca-certificates
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
 # Update the loader's cache

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -141,6 +141,8 @@ FROM debian:buster-slim
 
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
+# Update the loader's cache
+RUN ldconfig
 # Copy to /build/out as well for backward compatibility with previous versions.
 COPY --from=builder /build/out /build/out
 # Wrapper scripts

--- a/chrome/Dockerfile.alpine
+++ b/chrome/Dockerfile.alpine
@@ -140,5 +140,7 @@ FROM alpine:3.15.0
 
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
+# Update the loader's cache
+RUN ldconfig
 # Wrapper scripts
 COPY --from=builder /build/out/curl_* /usr/local/bin/

--- a/chrome/Dockerfile.alpine
+++ b/chrome/Dockerfile.alpine
@@ -137,7 +137,6 @@ RUN chmod +x out/curl_*
 # Create a final, minimal image with the compiled binaries
 # only.
 FROM alpine:3.15.0
-
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
 # Wrapper scripts

--- a/chrome/Dockerfile.alpine
+++ b/chrome/Dockerfile.alpine
@@ -134,7 +134,7 @@ COPY curl_chrome* curl_edge* curl_safari* out/
 RUN sed -i 's@/usr/bin/env bash@/usr/bin/env ash@' out/curl_*
 RUN chmod +x out/curl_*
 
-# When using alpine, create a final, minimal image with the compiled binaries
+# Create a final, minimal image with the compiled binaries
 # only.
 FROM alpine:3.15.0
 

--- a/chrome/Dockerfile.alpine
+++ b/chrome/Dockerfile.alpine
@@ -140,7 +140,5 @@ FROM alpine:3.15.0
 
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
-# Update the loader's cache
-RUN ldconfig
 # Wrapper scripts
 COPY --from=builder /build/out/curl_* /usr/local/bin/

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -7,7 +7,7 @@
 
 # Python is needed for building libnss.
 # Use it as a common base.
-FROM python:3.10.1-slim-buster
+FROM python:3.10.1-slim-buster as builder
 
 WORKDIR /build
 
@@ -130,3 +130,18 @@ RUN ! (ldd ./out/curl-impersonate | grep -q -e nghttp2 -e brotli -e ssl -e crypt
 # Wrapper scripts
 COPY curl_ff* out/
 RUN chmod +x out/curl_*
+
+# Create a final, minimal image with the compiled binaries
+# only.
+FROM debian:buster-slim
+# curl tries to load the CA certificates for libnss.
+# It loads them from /usr/lib/libnssckbi.so and /usr/lib/libnsspem.so,
+# which are supplied by 'libnss3' and 'nss-plugin-pem' on debian.
+RUN apt-get update && apt-get install -y libnss3 nss-plugin-pem
+
+# Copy curl-impersonate from the builder image
+COPY --from=builder /build/install /usr/local
+# Copy to /build/out as well for backward compatibility with previous versions.
+COPY --from=builder /build/out /build/out
+# Wrapper scripts
+COPY --from=builder /build/out/curl_* /usr/local/bin/

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -141,6 +141,8 @@ RUN apt-get update && apt-get install -y libnss3 nss-plugin-pem
 
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
+# Update the loader's cache
+RUN ldconfig
 # Copy to /build/out as well for backward compatibility with previous versions.
 COPY --from=builder /build/out /build/out
 # Wrapper scripts

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -134,11 +134,11 @@ RUN chmod +x out/curl_*
 # Create a final, minimal image with the compiled binaries
 # only.
 FROM debian:buster-slim
+RUN apt-get update && apt-get install -y ca-certificates
 # curl tries to load the CA certificates for libnss.
 # It loads them from /usr/lib/libnssckbi.so and /usr/lib/libnsspem.so,
 # which are supplied by 'libnss3' and 'nss-plugin-pem' on debian.
-RUN apt-get update && apt-get install -y libnss3 nss-plugin-pem
-
+RUN apt-get install -y libnss3 nss-plugin-pem
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
 # Update the loader's cache

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -126,7 +126,7 @@ COPY curl_ff* out/
 RUN sed -i 's@/usr/bin/env bash@/usr/bin/env ash@' out/curl_*
 RUN chmod +x out/curl_*
 
-# When using alpine, create a final, minimal image with the compiled binaries
+# Create a final, minimal image with the compiled binaries
 # only.
 FROM alpine:3.15.0
 # curl tries to load the CA certificates for libnss.

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -136,5 +136,7 @@ RUN apk add --no-cache nss
 
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
+# Update the loader's cache
+RUN ldconfig
 # Wrapper scripts
 COPY --from=builder /build/out/curl_* /usr/local/bin/

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -133,7 +133,6 @@ FROM alpine:3.15.0
 # It loads them from /usr/lib/libnssckbi.so,
 # which is supplied by 'nss' on alpine.
 RUN apk add --no-cache nss
-
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
 # Wrapper scripts

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -136,7 +136,5 @@ RUN apk add --no-cache nss
 
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
-# Update the loader's cache
-RUN ldconfig
 # Wrapper scripts
 COPY --from=builder /build/out/curl_* /usr/local/bin/

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -16,21 +16,19 @@ COPY requirements.txt requirements.txt
 RUN pip install --upgrade pip && \
     pip install -r requirements.txt
 
-RUN mkdir /tests/firefox /tests/chrome
-
 # Copy the built binaries from both containers
-COPY --from=ff /build/out/curl-impersonate-ff /tests/install/bin/
-COPY --from=ff /build/out/curl_* /tests/install/bin/
-COPY --from=ff /build/out/libcurl-impersonate* /tests/install/lib/
-COPY --from=chrome /build/out/curl-impersonate-chrome /tests/install/bin/
-COPY --from=chrome /build/out/curl_* /tests/install/bin/
-COPY --from=chrome /build/out/libcurl-impersonate* /tests/install/lib/
+COPY --from=ff /usr/local/ /usr/local/
+COPY --from=chrome /usr/local/ /usr/local/
+
+# Needed to update the loader's cache
+RUN ldconfig
 
 COPY . .
 
 # Compile 'minicurl' which is used for testing libcurl-impersonate.
 # 'minicurl' is compiled against the "regular" libcurl.
 # libcurl-impersonate will replace it at runtime via LD_PRELOAD.
-RUN gcc -Wall -Werror -o /tests/install/bin/minicurl minicurl.c `curl-config --libs`
+RUN gcc -Wall -Werror -o minicurl minicurl.c `curl-config --libs`
+RUN install minicurl /usr/local/bin
 
-ENTRYPOINT ["pytest", "--install-dir", "/tests/install"]
+ENTRYPOINT ["pytest"]


### PR DESCRIPTION
Push Debian-based Docker images to DockerHub automatically on each
release. The Debian images are suffixed with "-slim-buster" suffix.

Fixes #93 