### PR TITLE
Fix --disable-static and --enable-static=no

### DIFF
--- a/configure
+++ b/configure
@@ -4101,7 +4101,7 @@ fi
 # Check whether --enable-static was given.
 if test ${enable_static+y}
 then :
-  enableval=$enable_static; static_build="yes"
+  enableval=$enable_static; static_build="$enableval"
 
 else $as_nop
   static_build="no"

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ AC_CHECK_TOOL([STRIP], [strip])
 AC_ARG_ENABLE([static],
     [AS_HELP_STRING([--enable-static],
         [Build curl-impersonate statically with libcurl-impersonate])],
-    [AC_SUBST([static_build], ["yes"])],
+    [AC_SUBST([static_build], ["$enableval"])],
     [AC_SUBST([static_build], ["no"])])
 
 # Let the user optionally specify the path to zlib.


### PR DESCRIPTION
This PR corrects a small typo that caused `--disable-static` (which is a flag some distro packaging systems add by default) to actually enable a static build rather than explicitly disable it

For reference (see warning): https://autotools.info/autoconf/arguments.html#autoconf.adding-options.ac-arg-enable-with