### PR TITLE
Dockerfile: use bullseye as Debian base

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -67,8 +67,8 @@ jobs:
         with:
           images: lwthiker/curl-impersonate
           tags: |
-            type=semver,pattern={{version}},suffix=-chrome-slim-buster
-            type=semver,pattern={{major}}.{{minor}},suffix=-chrome-slim-buster
+            type=semver,pattern={{version}},suffix=-chrome-slim-bullseye
+            type=semver,pattern={{major}}.{{minor}},suffix=-chrome-slim-bullseye
 
       - name: Build and push the Chrome version of curl-impersonate
         uses: docker/build-push-action@v2
@@ -85,8 +85,8 @@ jobs:
         with:
           images: lwthiker/curl-impersonate
           tags: |
-            type=semver,pattern={{version}},suffix=-ff-slim-buster
-            type=semver,pattern={{major}}.{{minor}},suffix=-ff-slim-buster
+            type=semver,pattern={{version}},suffix=-ff-slim-bullseye
+            type=semver,pattern={{major}}.{{minor}},suffix=-ff-slim-bullseye
 
       - name: Build and push the Firefox version of curl-impersonate
         uses: docker/build-push-action@v2

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -8,7 +8,7 @@
 {{#debian}}
 # Python is needed for building libnss.
 # Use it as a common base.
-FROM python:3.10.1-slim-buster as builder
+FROM python:3.10.1-slim-bullseye as builder
 {{/debian}}
 {{#alpine}}
 FROM alpine:3.15.0 as builder
@@ -238,7 +238,7 @@ RUN apk add --no-cache nss
 {{/firefox}}
 {{/alpine}}
 {{#debian}}
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y ca-certificates
 {{#firefox}}
 # curl tries to load the CA certificates for libnss.

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -7,7 +7,7 @@
 
 # Python is needed for building libnss.
 # Use it as a common base.
-FROM python:3.10.1-slim-buster as builder
+FROM python:3.10.1-slim-bullseye as builder
 
 WORKDIR /build
 
@@ -137,7 +137,7 @@ RUN chmod +x out/curl_*
 
 # Create a final, minimal image with the compiled binaries
 # only.
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y ca-certificates
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -7,7 +7,7 @@
 
 # Python is needed for building libnss.
 # Use it as a common base.
-FROM python:3.10.1-slim-buster as builder
+FROM python:3.10.1-slim-bullseye as builder
 
 WORKDIR /build
 
@@ -133,7 +133,7 @@ RUN chmod +x out/curl_*
 
 # Create a final, minimal image with the compiled binaries
 # only.
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y ca-certificates
 # curl tries to load the CA certificates for libnss.
 # It loads them from /usr/lib/libnssckbi.so and /usr/lib/libnsspem.so,

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -4,7 +4,7 @@ ARG CHROME_IMAGE=curl-impersonate-chrome
 FROM ${FIREFOX_IMAGE} as ff
 FROM ${CHROME_IMAGE} as chrome
 
-FROM python:3.10.1-slim-buster
+FROM python:3.10.1-slim-bullseye
 
 WORKDIR /tests
 


### PR DESCRIPTION
Debian Bullseye was released over a year ago, so I suppose using it as a basis for Docker Debain image makes more sense?
It would also help incorporating it in other images, which rather tend to be based on current stable releases. See e.g. https://github.com/RSS-Bridge/rss-bridge/pull/2941#issuecomment-1208569045

Run and tested locally, seems to work just fine.