### PR TITLE
Impersonate Firefox 109

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -10,8 +10,8 @@ SHELL := bash
 
 BROTLI_VERSION := 1.0.9
  # In case this is changed, update build-and-test-make.yml as well
-NSS_VERSION := nss-3.77
-NSS_URL := https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_77_RTM/src/nss-3.77-with-nspr-4.32.tar.gz
+NSS_VERSION := nss-3.87
+NSS_URL := https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_87_RTM/src/nss-3.87-with-nspr-4.35.tar.gz
  # In case this is changed, update build-and-test-make.yml as well
 BORING_SSL_COMMIT := 3a667d10e94186fd503966f5638e134fe9fb4080
 NGHTTP2_VERSION := nghttp2-1.46.0

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The following browsers can be impersonated.
 | ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_24x24.png "Firefox") | 98 | 98.0 | Windows 10 | `ff98` | [curl_ff98](firefox/curl_ff98) |
 | ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_24x24.png "Firefox") | 100 | 100.0 | Windows 10 | `ff100` | [curl_ff100](firefox/curl_ff100) |
 | ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_24x24.png "Firefox") | 102 | 102.0 | Windows 10 | `ff102` | [curl_ff102](firefox/curl_ff102) |
+| ![Firefox](https://raw.githubusercontent.com/alrra/browser-logos/main/src/firefox/firefox_24x24.png "Firefox") | 109 | 109.0 | Windows 10 | `ff109` | [curl_ff109](firefox/curl_ff109) |
 | ![Safari](https://github.com/alrra/browser-logos/blob/main/src/safari/safari_24x24.png "Safari") | 15.3 | 16612.4.9.1.8 | MacOS Big Sur | `safari15_3` | [curl_safari15_3](chrome/curl_safari15_3) |
 | ![Safari](https://github.com/alrra/browser-logos/blob/main/src/safari/safari_24x24.png "Safari") | 15.5 | 17613.2.7.1.8 | MacOS Monterey | `safari15_5` | [curl_safari15_5](chrome/curl_safari15_5) |
 

--- a/browsers.json
+++ b/browsers.json
@@ -132,6 +132,16 @@
             "wrapper_script": "curl_ff102"
         },
         {
+            "name": "ff109",
+            "browser": {
+                "name": "firefox",
+                "version": "109.0",
+                "os": "win10"
+            },
+            "binary": "curl-impersonate-ff",
+            "wrapper_script": "curl_ff109"
+        },
+        {
             "name": "safari15_3",
             "browser": {
                 "name": "safari",

--- a/firefox/curl_ff109
+++ b/firefox/curl_ff109
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Find the directory of this script
+dir=${0%/*}
+
+# The list of ciphers can be obtained by looking at the Client Hello message in
+# Wireshark, then converting it using the cipherlist array at
+# https://github.com/curl/curl/blob/master/lib/vtls/nss.c
+"$dir/curl-impersonate-ff" \
+    --ciphers aes_128_gcm_sha_256,chacha20_poly1305_sha_256,aes_256_gcm_sha_384,ecdhe_ecdsa_aes_128_gcm_sha_256,ecdhe_rsa_aes_128_gcm_sha_256,ecdhe_ecdsa_chacha20_poly1305_sha_256,ecdhe_rsa_chacha20_poly1305_sha_256,ecdhe_ecdsa_aes_256_gcm_sha_384,ecdhe_rsa_aes_256_gcm_sha_384,ecdhe_ecdsa_aes_256_sha,ecdhe_ecdsa_aes_128_sha,ecdhe_rsa_aes_128_sha,ecdhe_rsa_aes_256_sha,rsa_aes_128_gcm_sha_256,rsa_aes_256_gcm_sha_384,rsa_aes_128_sha,rsa_aes_256_sha \
+    -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/109.0' \
+    -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' \
+    -H 'Accept-Language: en-US,en;q=0.5' \
+    -H 'Accept-Encoding: gzip, deflate, br' \
+    -H 'Upgrade-Insecure-Requests: 1' \
+    -H 'Sec-Fetch-Dest: document' \
+    -H 'Sec-Fetch-Mode: navigate' \
+    -H 'Sec-Fetch-Site: none' \
+    -H 'Sec-Fetch-User: ?1' \
+    -H 'TE: Trailers' \
+    --http2 --false-start --compressed \
+    "$@"

--- a/firefox/patches/curl-impersonate.patch
+++ b/firefox/patches/curl-impersonate.patch
@@ -785,10 +785,10 @@ index f6364d0e0..b5cb05e7e 100644
       called by nghttp2_session_mem_recv() will write stream specific
 diff --git a/lib/impersonate.c b/lib/impersonate.c
 new file mode 100644
-index 000000000..086fb383a
+index 000000000..33b822c1a
 --- /dev/null
 +++ b/lib/impersonate.c
-@@ -0,0 +1,186 @@
+@@ -0,0 +1,221 @@
 +#include "curl_setup.h"
 +
 +#include "impersonate.h"
@@ -959,6 +959,41 @@ index 000000000..086fb383a
 +      "rsa_aes_256_sha",
 +    .http_headers = {
 +      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:102.0) Gecko/20100101 Firefox/102.0",
++      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
++      "Accept-Language: en-US,en;q=0.5",
++      "Accept-Encoding: gzip, deflate, br",
++      "Upgrade-Insecure-Requests: 1",
++      "Sec-Fetch-Dest: document",
++      "Sec-Fetch-Mode: navigate",
++      "Sec-Fetch-Site: none",
++      "Sec-Fetch-User: ?1",
++      "TE: Trailers"
++    }
++  },
++  {
++    .target = "ff109",
++    .httpversion = CURL_HTTP_VERSION_2_0,
++    .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
++    .ciphers =
++      "aes_128_gcm_sha_256,"
++      "chacha20_poly1305_sha_256,"
++      "aes_256_gcm_sha_384,"
++      "ecdhe_ecdsa_aes_128_gcm_sha_256,"
++      "ecdhe_rsa_aes_128_gcm_sha_256,"
++      "ecdhe_ecdsa_chacha20_poly1305_sha_256,"
++      "ecdhe_rsa_chacha20_poly1305_sha_256,"
++      "ecdhe_ecdsa_aes_256_gcm_sha_384,"
++      "ecdhe_rsa_aes_256_gcm_sha_384,"
++      "ecdhe_ecdsa_aes_256_sha,"
++      "ecdhe_ecdsa_aes_128_sha,"
++      "ecdhe_rsa_aes_128_sha,"
++      "ecdhe_rsa_aes_256_sha,"
++      "rsa_aes_128_gcm_sha_256,"
++      "rsa_aes_256_gcm_sha_384,"
++      "rsa_aes_128_sha,"
++      "rsa_aes_256_sha",
++    .http_headers = {
++      "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/109.0",
 +      "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
 +      "Accept-Language: en-US,en;q=0.5",
 +      "Accept-Encoding: gzip, deflate, br",

--- a/tests/signatures/firefox.yaml
+++ b/tests/signatures/firefox.yaml
@@ -439,3 +439,91 @@ signature:
             - 'sec-fetch-site: none'
             - 'sec-fetch-user: ?1'
             - 'te: trailers'
+---
+name: firefox_109.0_win10
+browser:
+    name: firefox
+    version: 109.0
+    os: win10
+    mode: regular
+signature:
+    tls_client_hello:
+        record_version: 'TLS_VERSION_1_0'
+        handshake_version: 'TLS_VERSION_1_2'
+        session_id_length: 32
+        ciphersuites: [
+            0x1301, 0x1303, 0x1302, 0xc02b, 0xc02f, 0xcca9, 0xcca8, 0xc02c,
+            0xc030, 0xc00a, 0xc009, 0xc013, 0xc014, 0x009c, 0x009d, 0x002f,
+            0x0035
+        ]
+        comp_methods: [0x00]
+        extensions:
+            - type: server_name
+            - type: extended_master_secret
+              length: 0
+            - type: renegotiation_info
+              length: 1
+            - type: supported_groups
+              length: 14
+              supported_groups: [
+                  0x1d, 0x017, 0x18, 0x19, 0x0100, 0x0101
+              ]
+            - type: ec_point_formats
+              length: 2
+              ec_point_formats: [0]
+            - type: session_ticket
+              length: 0
+            - type: application_layer_protocol_negotiation
+              length: 14
+              alpn_list: ['h2', 'http/1.1']
+            - type: status_request
+              length: 5
+              status_request_type: 0x01
+            - type: delegated_credentials
+              length: 10
+              sig_hash_algs: [
+                  0x0403, 0x0503, 0x0603, 0x0203
+              ]
+            - type: keyshare
+              length: 107
+              key_shares:
+                  - group: 29
+                    length: 32
+                  - group: 23
+                    length: 65
+            - type: supported_versions
+              length: 5
+              supported_versions: [
+                  'TLS_VERSION_1_3', 'TLS_VERSION_1_2'
+              ]
+            - type: signature_algorithms
+              length: 24
+              sig_hash_algs: [
+                  0x0403, 0x0503, 0x0603, 0x0804,
+                  0x0805, 0x0806, 0x0401, 0x0501,
+                  0x0601, 0x0203, 0x0201
+              ]
+            - type: psk_key_exchange_modes
+              length: 2
+              psk_ke_mode: 1
+            - type: record_size_limit
+              length: 2
+              record_size_limit: 16385
+            - type: padding
+    http2:
+        pseudo_headers:
+            - ':method'
+            - ':path'
+            - ':authority'
+            - ':scheme'
+        headers:
+            - 'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/109.0'
+            - 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8'
+            - 'accept-language: en-US,en;q=0.5'
+            - 'accept-encoding: gzip, deflate, br'
+            - 'upgrade-insecure-requests: 1'
+            - 'sec-fetch-dest: document'
+            - 'sec-fetch-mode: navigate'
+            - 'sec-fetch-site: none'
+            - 'sec-fetch-user: ?1'
+            - 'te: trailers'

--- a/tests/test_impersonate.py
+++ b/tests/test_impersonate.py
@@ -158,6 +158,7 @@ class TestImpersonation:
         ("curl_ff98", None, None, "firefox_98.0_win10"),
         ("curl_ff100", None, None, "firefox_100.0_win10"),
         ("curl_ff102", None, None, "firefox_102.0_win10"),
+        ("curl_ff109", None, None, "firefox_109.0_win10"),
 
         # Test libcurl-impersonate by loading it with LD_PRELOAD to an app
         # linked against the regular libcurl and setting the
@@ -281,6 +282,14 @@ class TestImpersonation:
             },
             "libcurl-impersonate-ff",
             "firefox_102.0_win10"
+        ),
+        (
+            "minicurl",
+            {
+                "CURL_IMPERSONATE": "ff109"
+            },
+            "libcurl-impersonate-ff",
+            "firefox_109.0_win10"
         )
     ]
 


### PR DESCRIPTION
Firefox impersonation was not updated in a long while. Add impersonation for Firefox 109. The TLS signature is identical to previous versions, with the usual changes to the HTTP headers.

Update NSS to the latest version as well, even though it is not strictly necessary for the impersonation.