### PR TITLE
Impersonate Chrome 110

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following browsers can be impersonated.
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 101 | 101.0.4951.67 | Windows 10 | `chrome101` | [curl_chrome101](chrome/curl_chrome101) |
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 104 | 104.0.5112.81 | Windows 10 | `chrome104` | [curl_chrome104](chrome/curl_chrome104) |
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 107 | 107.0.5304.107 | Windows 10 | `chrome107` | [curl_chrome107](chrome/curl_chrome107) |
-| ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 109 | 109.0.5414.119 | Windows 10 | `chrome109` | [curl_chrome109](chrome/curl_chrome109) |
+| ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 110 | 110.0.5481.177 | Windows 10 | `chrome110` | [curl_chrome110](chrome/curl_chrome110) |
 | ![Chrome](https://raw.githubusercontent.com/alrra/browser-logos/main/src/chrome/chrome_24x24.png "Chrome") | 99 | 99.0.4844.73 | Android 12 | `chrome99_android` | [curl_chrome99_android](chrome/curl_chrome99_android) |
 | ![Edge](https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge/edge_24x24.png "Edge") | 99 | 99.0.1150.30 | Windows 10 | `edge99` | [curl_edge99](chrome/curl_edge99) |
 | ![Edge](https://raw.githubusercontent.com/alrra/browser-logos/main/src/edge/edge_24x24.png "Edge") | 101 | 101.0.1210.47 | Windows 10 | `edge101` | [curl_edge101](chrome/curl_edge101) |

--- a/browsers.json
+++ b/browsers.json
@@ -51,14 +51,14 @@
             "wrapper_script": "curl_chrome107"
         },
         {
-            "name": "chrome109",
+            "name": "chrome110",
             "browser": {
                 "name": "chrome",
-                "version": "109.0.5414.119",
+                "version": "110.0.5481.177",
                 "os": "win10"
             },
             "binary": "curl-impersonate-chrome",
-            "wrapper_script": "curl_chrome109"
+            "wrapper_script": "curl_chrome110"
         },
         {
             "name": "chrome99_android",

--- a/chrome/curl_chrome110
+++ b/chrome/curl_chrome110
@@ -8,12 +8,12 @@ dir=${0%/*}
 # https://wiki.mozilla.org/Security/Cipher_Suites
 "$dir/curl-impersonate-chrome" \
     --ciphers TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-CHACHA20-POLY1305,ECDHE-RSA-CHACHA20-POLY1305,ECDHE-RSA-AES128-SHA,ECDHE-RSA-AES256-SHA,AES128-GCM-SHA256,AES256-GCM-SHA384,AES128-SHA,AES256-SHA \
-    -H 'sec-ch-ua: "Not_A Brand";v="99", "Google Chrome";v="109", "Chromium";v="109"' \
+    -H 'sec-ch-ua: "Chromium";v="110", "Not A(Brand";v="24", "Google Chrome";v="110"' \
     -H 'sec-ch-ua-mobile: ?0' \
     -H 'sec-ch-ua-platform: "Windows"' \
     -H 'Upgrade-Insecure-Requests: 1' \
-    -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36' \
-    -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9' \
+    -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36' \
+    -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7' \
     -H 'Sec-Fetch-Site: none' \
     -H 'Sec-Fetch-Mode: navigate' \
     -H 'Sec-Fetch-User: ?1' \

--- a/chrome/patches/curl-impersonate.patch
+++ b/chrome/patches/curl-impersonate.patch
@@ -82,10 +82,10 @@ index aaf2b8a43..ccfa52985 100644
            echo "curl was built with static libraries disabled" >&2
            exit 1
 diff --git a/include/curl/curl.h b/include/curl/curl.h
-index b00648e79..b64234932 100644
+index b00648e79..a8edd2e2d 100644
 --- a/include/curl/curl.h
 +++ b/include/curl/curl.h
-@@ -2143,6 +2143,49 @@ typedef enum {
+@@ -2143,6 +2143,50 @@ typedef enum {
    /* set the SSH host key callback custom pointer */
    CURLOPT(CURLOPT_SSH_HOSTKEYDATA, CURLOPTTYPE_CBPOINT, 317),
  
@@ -127,7 +127,8 @@ index b00648e79..b64234932 100644
 +   */
 +  CURLOPT(CURLOPT_HTTP2_NO_SERVER_PUSH, CURLOPTTYPE_LONG, 324),
 +
-+  /* curl-impersonate: Whether to enable Boringssl permute extensions
++  /* 
++   * curl-impersonate: Whether to enable Boringssl permute extensions
 +   * See https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_set_permute_extensions.
 +   */
 +  CURLOPT(CURLOPT_SSL_PERMUTE_EXTENSIONS, CURLOPTTYPE_LONG, 325),
@@ -249,7 +250,7 @@ index 9bd8e324b..bfd5e90e2 100644
    inet_pton.c        \
    krb5.c             \
 diff --git a/lib/easy.c b/lib/easy.c
-index 704a59df6..bc4d33b47 100644
+index 704a59df6..f486362c0 100644
 --- a/lib/easy.c
 +++ b/lib/easy.c
 @@ -81,6 +81,8 @@
@@ -261,7 +262,7 @@ index 704a59df6..bc4d33b47 100644
  
  /* The last 3 #include files should be in this order */
  #include "curl_printf.h"
-@@ -332,6 +334,136 @@ CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
+@@ -332,6 +334,134 @@ CURLsslset curl_global_sslset(curl_sslbackend id, const char *name,
    return rc;
  }
  
@@ -338,6 +339,12 @@ index 704a59df6..bc4d33b47 100644
 +  if(ret)
 +    return ret;
 +
++  if(opts->tls_permute_extensions) {
++    ret = curl_easy_setopt(data, CURLOPT_SSL_PERMUTE_EXTENSIONS, 1);
++    if(ret)
++      return ret;
++  }
++
 +  if(opts->cert_compression) {
 +    ret = curl_easy_setopt(data,
 +                           CURLOPT_SSL_CERT_COMPRESSION,
@@ -373,14 +380,6 @@ index 704a59df6..bc4d33b47 100644
 +      return ret;
 +  }
 +
-+  if(opts->tls_permute_extensions) {
-+    ret = curl_easy_setopt(data,
-+                           CURLOPT_SSL_PERMUTE_EXTENSIONS,
-+                           opts->tls_permute_extensions ? 1 : 0);
-+    if(ret)
-+      return ret;
-+  }
-+
 +  if(opts->http2_no_server_push) {
 +    ret = curl_easy_setopt(data, CURLOPT_HTTP2_NO_SERVER_PUSH, 1L);
 +    if(ret)
@@ -398,7 +397,7 @@ index 704a59df6..bc4d33b47 100644
  /*
   * curl_easy_init() is the external interface to alloc, setup and init an
   * easy handle that is returned. If anything goes wrong, NULL is returned.
-@@ -340,6 +472,8 @@ struct Curl_easy *curl_easy_init(void)
+@@ -340,6 +470,8 @@ struct Curl_easy *curl_easy_init(void)
  {
    CURLcode result;
    struct Curl_easy *data;
@@ -407,7 +406,7 @@ index 704a59df6..bc4d33b47 100644
  
    /* Make sure we inited the global SSL stuff */
    global_init_lock();
-@@ -362,6 +496,29 @@ struct Curl_easy *curl_easy_init(void)
+@@ -362,6 +494,29 @@ struct Curl_easy *curl_easy_init(void)
      return NULL;
    }
  
@@ -437,7 +436,7 @@ index 704a59df6..bc4d33b47 100644
    return data;
  }
  
-@@ -936,6 +1093,13 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
+@@ -936,6 +1091,13 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
      outcurl->state.referer_alloc = TRUE;
    }
  
@@ -451,7 +450,7 @@ index 704a59df6..bc4d33b47 100644
    /* Reinitialize an SSL engine for the new handle
     * note: the engine name has already been copied by dupset */
    if(outcurl->set.str[STRING_SSL_ENGINE]) {
-@@ -1025,6 +1189,9 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
+@@ -1025,6 +1187,9 @@ struct Curl_easy *curl_easy_duphandle(struct Curl_easy *data)
   */
  void curl_easy_reset(struct Curl_easy *data)
  {
@@ -461,7 +460,7 @@ index 704a59df6..bc4d33b47 100644
    Curl_free_request_state(data);
  
    /* zero out UserDefined data: */
-@@ -1049,6 +1216,23 @@ void curl_easy_reset(struct Curl_easy *data)
+@@ -1049,6 +1214,23 @@ void curl_easy_reset(struct Curl_easy *data)
  #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_CRYPTO_AUTH)
    Curl_http_auth_cleanup_digest(data);
  #endif
@@ -1018,7 +1017,7 @@ index f0390596c..cf9b7a9d5 100644
   * Store nghttp2 version info in this buffer.
 diff --git a/lib/impersonate.c b/lib/impersonate.c
 new file mode 100644
-index 000000000..21d6e2409
+index 000000000..025bd58ef
 --- /dev/null
 +++ b/lib/impersonate.c
 @@ -0,0 +1,480 @@
@@ -1229,7 +1228,7 @@ index 000000000..21d6e2409
 +    .http2_no_server_push = true
 +  },
 +  {
-+      .target = "chrome109",
++      .target = "chrome110",
 +      .httpversion = CURL_HTTP_VERSION_2_0,
 +      .ssl_version = CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_DEFAULT,
 +      .ciphers =
@@ -1255,12 +1254,12 @@ index 000000000..21d6e2409
 +      .tls_session_ticket = true,
 +      .cert_compression = "brotli",
 +      .http_headers = {
-+              "sec-ch-ua: \"\"Not=A?Brand\";v=\"99\", Google Chrome\";v=\"109\", \"Chromium\";v=\"109\"",
++              "sec-ch-ua: \"Chromium\";v=\"110\", \"Not A(Brand\";v=\"24\", \"Google Chrome\";v=\"110\"",
 +              "sec-ch-ua-mobile: ?0",
 +              "sec-ch-ua-platform: \"Windows\"",
 +              "Upgrade-Insecure-Requests: 1",
-+              "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36",
-+              "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
++              "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36",
++              "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
 +              "Sec-Fetch-Site: none",
 +              "Sec-Fetch-Mode: navigate",
 +              "Sec-Fetch-User: ?1",
@@ -1805,7 +1804,7 @@ index bcb4d460c..01e015706 100644
  
  struct Names {
 diff --git a/lib/vtls/openssl.c b/lib/vtls/openssl.c
-index 78aacd022..1d18fac7e 100644
+index 78aacd022..9f66af846 100644
 --- a/lib/vtls/openssl.c
 +++ b/lib/vtls/openssl.c
 @@ -78,6 +78,13 @@
@@ -2140,7 +2139,7 @@ index 78aacd022..1d18fac7e 100644
  #ifdef USE_OPENSSL_SRP
    if((ssl_authtype == CURL_TLSAUTH_SRP) &&
       Curl_allow_auth_to_host(data)) {
-@@ -2933,6 +3228,24 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
+@@ -2933,6 +3228,28 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
    }
  #endif
  
@@ -2153,6 +2152,10 @@ index 78aacd022..1d18fac7e 100644
 +  /* Enable TLS GREASE. */
 +  SSL_CTX_set_grease_enabled(backend->ctx, 1);
 +
++  /*
++   * curl-impersonate: Enable TLS extension permutation, enabled by default
++   * since Chrome 110.
++   */
 +  if(conn->bits.tls_permute_extensions) {
 +    SSL_CTX_set_permute_extensions(backend->ctx, 1);
 +  }
@@ -2165,7 +2168,7 @@ index 78aacd022..1d18fac7e 100644
  
  #if defined(USE_WIN32_CRYPTO)
    /* Import certificates from the Windows root certificate store if requested.
-@@ -3232,6 +3545,33 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
+@@ -3232,6 +3549,33 @@ static CURLcode ossl_connect_step1(struct Curl_easy *data,
  
    SSL_set_connect_state(backend->handle);
  

--- a/tests/signatures/chrome.yaml
+++ b/tests/signatures/chrome.yaml
@@ -588,7 +588,6 @@ signature:
   tls_client_hello:
     record_version: 'TLS_VERSION_1_0'
     handshake_version: 'TLS_VERSION_1_2'
-    permute_extension: true
     session_id_length: 32
     ciphersuites: [
       'GREASE',

--- a/tests/signatures/chrome.yaml
+++ b/tests/signatures/chrome.yaml
@@ -563,7 +563,7 @@ signature:
             - ':scheme'
             - ':path'
         headers:
-            - 'sec-ch-ua: "Not_A Brand";v="99", "Google Chrome";v="109", "Chromium";v="109"'
+            - 'sec-ch-ua: "Google Chrome";v="107", "Chromium";v="107", "Not=A?Brand";v="24"'
             - 'sec-ch-ua-mobile: ?0'
             - 'sec-ch-ua-platform: "Windows"'
             - 'upgrade-insecure-requests: 1'

--- a/tests/signatures/chrome.yaml
+++ b/tests/signatures/chrome.yaml
@@ -575,103 +575,105 @@ signature:
             - 'sec-fetch-dest: document'
             - 'accept-encoding: gzip, deflate, br'
             - 'accept-language: en-US,en;q=0.9'
-#---
-#name: chrome_109.0.5414.119_win10
-#browser:
-#  name: chrome
-#  version: 109.0.5414.119
-#  os: win10
-#  mode: regular
-#signature:
-#  tls_client_hello:
-#    record_version: 'TLS_VERSION_1_0'
-#    handshake_version: 'TLS_VERSION_1_2'
-#    permute_extension: true
-#    session_id_length: 32
-#    ciphersuites: [
-#      'GREASE',
-#      0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030,
-#      0xcca9, 0xcca8, 0xc013, 0xc014, 0x009c, 0x009d, 0x002f,
-#      0x0035
-#    ]
-#    comp_methods: [0x00]
-#    extensions:
-#      - type: GREASE
-#        length: 0
-#      - type: server_name
-#      - type: extended_master_secret
-#        length: 0
-#      - type: renegotiation_info
-#        length: 1
-#      - type: supported_groups
-#        length: 10
-#        supported_groups: [
-#          'GREASE',
-#          0x001d, 0x0017, 0x0018
-#        ]
-#      - type: ec_point_formats
-#        length: 2
-#        ec_point_formats: [0]
-#      - type: session_ticket
-#        length: 0
-#      - type: application_layer_protocol_negotiation
-#        length: 14
-#        alpn_list: ['h2', 'http/1.1']
-#      - type: status_request
-#        length: 5
-#        status_request_type: 0x01
-#      - type: signature_algorithms
-#        length: 18
-#        sig_hash_algs: [
-#          0x0403, 0x0804, 0x0401, 0x0503,
-#          0x0805, 0x0501, 0x0806, 0x0601
-#        ]
-#      - type: signed_certificate_timestamp
-#        length: 0
-#      - type: keyshare
-#        length: 43
-#        key_shares:
-#          - group: GREASE
-#            length: 1
-#          - group: 29
-#            length: 32
-#      - type: psk_key_exchange_modes
-#        length: 2
-#        psk_ke_mode: 1
-#      - type: supported_versions
-#        length: 7
-#        supported_versions: [
-#          'GREASE', 'TLS_VERSION_1_3', 'TLS_VERSION_1_2'
-#        ]
-#      - type: compress_certificate
-#        length: 3
-#        algorithms: [0x02]
-#      - type: application_settings
-#        length: 5
-#        alps_alpn_list: ['h2']
-#      - type: GREASE
-#        length: 1
-#        data: !!binary AA==
-#      - type: padding
-#  http2:
-#    pseudo_headers:
-#      - ':method'
-#      - ':authority'
-#      - ':scheme'
-#      - ':path'
-#    headers:
-#      - 'sec-ch-ua: "Google Chrome";v="107", "Chromium";v="107", "Not=A?Brand";v="24"'
-#      - 'sec-ch-ua-mobile: ?0'
-#      - 'sec-ch-ua-platform: "Windows"'
-#      - 'upgrade-insecure-requests: 1'
-#      - 'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36'
-#      - 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9'
-#      - 'sec-fetch-site: none'
-#      - 'sec-fetch-mode: navigate'
-#      - 'sec-fetch-user: ?1'
-#      - 'sec-fetch-dest: document'
-#      - 'accept-encoding: gzip, deflate, br'
-#      - 'accept-language: en-US,en;q=0.9'
+---
+name: chrome_110.0.5481.177_win10
+browser:
+  name: chrome
+  version: 110.0.5481.177
+  os: win10
+  mode: regular
+signature:
+  options:
+    tls_permute_extensions: true
+  tls_client_hello:
+    record_version: 'TLS_VERSION_1_0'
+    handshake_version: 'TLS_VERSION_1_2'
+    permute_extension: true
+    session_id_length: 32
+    ciphersuites: [
+      'GREASE',
+      0x1301, 0x1302, 0x1303, 0xc02b, 0xc02f, 0xc02c, 0xc030,
+      0xcca9, 0xcca8, 0xc013, 0xc014, 0x009c, 0x009d, 0x002f,
+      0x0035
+    ]
+    comp_methods: [0x00]
+    extensions:
+      - type: GREASE
+        length: 0
+      - type: server_name
+      - type: extended_master_secret
+        length: 0
+      - type: renegotiation_info
+        length: 1
+      - type: supported_groups
+        length: 10
+        supported_groups: [
+          'GREASE',
+          0x001d, 0x0017, 0x0018
+        ]
+      - type: ec_point_formats
+        length: 2
+        ec_point_formats: [0]
+      - type: session_ticket
+        length: 0
+      - type: application_layer_protocol_negotiation
+        length: 14
+        alpn_list: ['h2', 'http/1.1']
+      - type: status_request
+        length: 5
+        status_request_type: 0x01
+      - type: signature_algorithms
+        length: 18
+        sig_hash_algs: [
+          0x0403, 0x0804, 0x0401, 0x0503,
+          0x0805, 0x0501, 0x0806, 0x0601
+        ]
+      - type: signed_certificate_timestamp
+        length: 0
+      - type: keyshare
+        length: 43
+        key_shares:
+          - group: GREASE
+            length: 1
+          - group: 29
+            length: 32
+      - type: psk_key_exchange_modes
+        length: 2
+        psk_ke_mode: 1
+      - type: supported_versions
+        length: 7
+        supported_versions: [
+          'GREASE', 'TLS_VERSION_1_3', 'TLS_VERSION_1_2'
+        ]
+      - type: compress_certificate
+        length: 3
+        algorithms: [0x02]
+      - type: application_settings
+        length: 5
+        alps_alpn_list: ['h2']
+      - type: GREASE
+        length: 1
+        data: !!binary AA==
+      - type: padding
+  http2:
+    pseudo_headers:
+      - ':method'
+      - ':authority'
+      - ':scheme'
+      - ':path'
+    headers:
+      - 'sec-ch-ua: "Chromium";v="110", "Not A(Brand";v="24", "Google Chrome";v="110"'
+      - 'sec-ch-ua-mobile: ?0'
+      - 'sec-ch-ua-platform: "Windows"'
+      - 'upgrade-insecure-requests: 1'
+      - 'user-agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36'
+      - 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7'
+      - 'sec-fetch-site: none'
+      - 'sec-fetch-mode: navigate'
+      - 'sec-fetch-user: ?1'
+      - 'sec-fetch-dest: document'
+      - 'accept-encoding: gzip, deflate, br'
+      - 'accept-language: en-US,en;q=0.9'
 ---
 name: chrome_99.0.4844.73_android12-pixel6
 browser:

--- a/tests/test_impersonate.py
+++ b/tests/test_impersonate.py
@@ -148,6 +148,7 @@ class TestImpersonation:
         ("curl_chrome101", None, None, "chrome_101.0.4951.67_win10"),
         ("curl_chrome104", None, None, "chrome_104.0.5112.81_win10"),
         ("curl_chrome107", None, None, "chrome_107.0.5304.107_win10"),
+        ("curl_chrome110", None, None, "chrome_110.0.5481.177_win10"),
         ("curl_chrome99_android", None, None, "chrome_99.0.4844.73_android12-pixel6"),
         ("curl_edge99", None, None, "edge_99.0.1150.30_win10"),
         ("curl_edge101", None, None, "edge_101.0.1210.47_win10"),
@@ -202,6 +203,14 @@ class TestImpersonation:
             },
             "libcurl-impersonate-chrome",
             "chrome_107.0.5304.107_win10"
+        ),
+        (
+            "minicurl",
+            {
+                "CURL_IMPERSONATE": "chrome110"
+            },
+            "libcurl-impersonate-chrome",
+            "chrome_110.0.5481.177_win10"
         ),
         (
             "minicurl",
@@ -556,7 +565,14 @@ class TestImpersonation:
                                   ["tls_client_hello"]
             )
 
-            equals, msg = sig.equals(expected_sig, reason=True)
+            allow_tls_permutation=browser_signatures[expected_signature]    \
+                                                    ["signature"]           \
+                                                    .get("options", {})     \
+                                                    .get("tls_permute_extensions", False)
+            equals, msg = sig.equals(
+                expected_sig,
+                allow_tls_permutation=allow_tls_permutation,
+                reason=True)
             assert equals, msg
 
     @pytest.mark.asyncio

--- a/tests/test_impersonate.py
+++ b/tests/test_impersonate.py
@@ -572,7 +572,8 @@ class TestImpersonation:
             equals, msg = sig.equals(
                 expected_sig,
                 allow_tls_permutation=allow_tls_permutation,
-                reason=True)
+                reason=True
+            )
             assert equals, msg
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Chrome 110 is out, and uses TLS extension permutation enabled by default. See https://chromestatus.com/feature/5124606246518784. This means that the TLS extension order is randomized in each TLS client hello message.

This PR is based on #142. Since Chrome 110 is already out, the Chrome 109 signature was upgraded to Chrome 110.