### PR TITLE
Cross-compile armv7l binaries for 32-bit Raspberry Pi's

### DIFF
--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -33,6 +33,11 @@ jobs:
             host: aarch64-linux-gnu
             capture_interface: eth0
             make: make
+          - os: ubuntu-20.04
+            arch: arm
+            host: arm-linux-gnueabihf
+            capture_interface: eth0
+            make: make
           - os: macos-11
             arch: x86_64
             host: x86_64-macos
@@ -55,10 +60,10 @@ jobs:
           # More dependencies for the tests
           sudo apt-get install tcpdump nghttp2-server libnss3
 
-      - name: Install Ubuntu dependencies (aarch64)
-        if: matrix.arch == 'aarch64'
+      - name: Install Ubuntu cross-compile dependencies (${{ matrix.arch }})
+        if: matrix.os == 'ubuntu-20.04' && matrix.arch != 'x86_64'
         run: |
-          sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          sudo apt-get install gcc-${{ matrix.host }} g++-${{ matrix.host }}
 
       - name: Install macOS dependencies
         if: matrix.os == 'macos-11'
@@ -177,7 +182,7 @@ jobs:
           ${{ matrix.make }} firefox-build
           ${{ matrix.make }} firefox-checkbuild
           ${{ matrix.make }} firefox-install
-    
+
       - name: Prepare the tests
         if: matrix.arch == 'x86_64'
         run: |

--- a/Makefile.in
+++ b/Makefile.in
@@ -381,16 +381,11 @@ $(CURL_VERSION)/.firefox: $(firefox_libs) $(CURL_VERSION).tar.xz $(CURL_VERSION)
 	  fi; \
 	  add_cflags="-I$(nss_install_dir)/../public/nss"; \
 	  add_cflags+=" -I$(nss_install_dir)/include/nspr"; \
-	  if test "$(host_cpu)" = "arm"; then \
-	    add_libs="-L$(nss_install_dir)/lib -l:libgcm-aes-arm32-neon_c_lib.a"; \
-	  else \
-	    add_libs=""; \
-	  fi; \
 	}
 
 	echo "Configuring curl with: $$config_flags"
 
-	./configure $$config_flags CFLAGS="$$add_cflags" LIBS="$$add_libs"
+	./configure $$config_flags CFLAGS="$$add_cflags"
 	# Remove possible leftovers from a previous compilation
 	$(MAKE) clean MAKEFLAGS=
 	touch .firefox

--- a/Makefile.in
+++ b/Makefile.in
@@ -225,6 +225,7 @@ else
 	    ;;                                     \
 	  *)                                       \
 	    use_64="0";                            \
+	    nspr_configure_flags="";               \
 	    ;;                                     \
 	esac
 
@@ -380,11 +381,16 @@ $(CURL_VERSION)/.firefox: $(firefox_libs) $(CURL_VERSION).tar.xz $(CURL_VERSION)
 	  fi; \
 	  add_cflags="-I$(nss_install_dir)/../public/nss"; \
 	  add_cflags+=" -I$(nss_install_dir)/include/nspr"; \
+	  if test "$(host_cpu)" = "arm"; then \
+	    add_libs="-L$(nss_install_dir)/lib -l:libgcm-aes-arm32-neon_c_lib.a"; \
+	  else \
+	    add_libs=""; \
+	  fi; \
 	}
 
 	echo "Configuring curl with: $$config_flags"
 
-	./configure $$config_flags CFLAGS="$$add_cflags"
+	./configure $$config_flags CFLAGS="$$add_cflags" LIBS="$$add_libs"
 	# Remove possible leftovers from a previous compilation
 	$(MAKE) clean MAKEFLAGS=
 	touch .firefox

--- a/chrome/patches/curl-impersonate.patch
+++ b/chrome/patches/curl-impersonate.patch
@@ -2485,3 +2485,17 @@ index 5ff86c7f5..be26f91ea 100644
    NV1(CURLOPT_TCP_NODELAY, 1),
    NV1(CURLOPT_PROXY_SSL_VERIFYPEER, 1),
    NV1(CURLOPT_PROXY_SSL_VERIFYHOST, 1),
+diff --git a/lib/easy_lock.h b/lib/easy_lock.h
+index 819f50ce8..1f54289ce 100644
+--- a/lib/easy_lock.h
++++ b/lib/easy_lock.h
+@@ -36,6 +36,9 @@
+ 
+ #elif defined (HAVE_ATOMIC)
+ #include <stdatomic.h>
++#if defined(HAVE_SCHED_YIELD)
++#include <sched.h>
++#endif
+ 
+ #define curl_simple_lock atomic_bool
+ #define CURL_SIMPLE_LOCK_INIT false

--- a/firefox/patches/curl-impersonate.patch
+++ b/firefox/patches/curl-impersonate.patch
@@ -1354,7 +1354,7 @@ index cb162755d..13ee571aa 100644
 +
 +      case $host_cpu in
 +        arm)
-+          addlib="$addlib -larmv8_c_lib"
++          addlib="$addlib -larmv8_c_lib -l:libgcm-aes-arm32-neon_c_lib.a"
 +          ;;
 +        aarch64)
 +          addlib="$addlib -larmv8_c_lib -lgcm-aes-aarch64_c_lib"

--- a/firefox/patches/curl-impersonate.patch
+++ b/firefox/patches/curl-impersonate.patch
@@ -1498,3 +1498,18 @@ index 706f0aac3..0ad94622e 100644
  endif
  
  # if unit tests are enabled, build a static library to link them with
+diff --git a/lib/easy_lock.h b/lib/easy_lock.h
+index 819f50ce8..1f54289ce 100644
+--- a/lib/easy_lock.h
++++ b/lib/easy_lock.h
+@@ -36,6 +36,9 @@
+ 
+ #elif defined (HAVE_ATOMIC)
+ #include <stdatomic.h>
++#if defined(HAVE_SCHED_YIELD)
++#include <sched.h>
++#endif
+ 
+ #define curl_simple_lock atomic_bool
+ #define CURL_SIMPLE_LOCK_INIT false
+


### PR DESCRIPTION
Though Raspberry Pi OS supports 64-bit with architecture aarch64, there are still users of the 32-bit OS with architecture armv7l. This change adds cross-compilation targeting the 32-bit armv7l architecture with a few tweaks:
- Patch compilation error due to `easy_lock.h` (this has been fixed upstream in curl 7.85+)
- Extend Makefile to include nss NEON libraries for Firefox build

I built the cross-compiled binaries locally with these changes and tested them on a Raspberry Pi 3b+ running 32-bit Raspbian bullseye.