### PR TITLE
Docker update base images

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -9,11 +9,9 @@
 # Python is needed for building libnss.
 # Use it as a common base.
 FROM python:3.11-slim-bookworm as builder
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 {{/debian}}
 {{#alpine}}
 FROM alpine:3.18 as builder
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 {{/alpine}}
 
 WORKDIR /build

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -98,7 +98,9 @@ COPY patches/boringssl-*.patch boringssl/
 RUN cd boringssl && \
     for p in $(ls boringssl-*.patch); do patch -p1 < $p; done && \
     mkdir build && cd build && \
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=on -GNinja .. && \
+    cmake \
+        -DCMAKE_C_FLAGS="-Wno-error=array-bounds -Wno-error=stringop-overflow" \
+        -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=on -GNinja .. && \
     ninja
 
 # Fix the directory structure so that curl can compile against it.
@@ -108,6 +110,11 @@ RUN mkdir boringssl/build/lib && \
     ln -s ../ssl/libssl.a boringssl/build/lib/libssl.a && \
     cp -R boringssl/include boringssl/build
 {{/chrome}}
+
+# Dependencies for downloading and building nghttp2
+{{#debian}}
+RUN apt-get install -y bzip2
+{{/debian}}
 
 ARG NGHTTP2_VERSION=nghttp2-1.46.0
 ARG NGHTTP2_URL=https://github.com/nghttp2/nghttp2/releases/download/v1.46.0/nghttp2-1.46.0.tar.bz2
@@ -120,6 +127,11 @@ RUN tar xf ${NGHTTP2_VERSION}.tar.bz2
 RUN cd ${NGHTTP2_VERSION} && \
     ./configure --prefix=/build/${NGHTTP2_VERSION}/installed --with-pic --disable-shared && \
     make && make install
+
+# Dependencies for downloading and building curl
+{{#debian}}
+RUN apt-get install -y xz-utils
+{{/debian}}
 
 # Download curl.
 ARG CURL_VERSION=curl-7.84.0

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,6 +1,6 @@
 #
 # NOTE: THIS DOCKERFILE IS GENERATED FROM "Dockerfile.template" VIA
-# "generate-dockerfiles.sh".
+# `./generate_dockerfiles.sh`
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
@@ -8,10 +8,12 @@
 {{#debian}}
 # Python is needed for building libnss.
 # Use it as a common base.
-FROM python:3.10.1-slim-bullseye as builder
+FROM python:3.11-slim-bookworm as builder
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 {{/debian}}
 {{#alpine}}
-FROM alpine:3.15.0 as builder
+FROM alpine:3.18 as builder
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 {{/alpine}}
 
 WORKDIR /build
@@ -22,7 +24,7 @@ RUN apt-get update && \
     apt-get install -y git ninja-build cmake curl zlib1g-dev
 {{/debian}}
 {{#alpine}}
-RUN apk add git build-base make cmake ninja curl zlib-dev patch linux-headers python3 python3-dev
+RUN apk add git bash build-base make cmake ninja curl zlib-dev patch linux-headers python3 python3-dev
 {{/alpine}}
 
 # The following are needed because we are going to change some autoconf scripts,
@@ -229,7 +231,7 @@ RUN chmod +x out/curl_*
 # Create a final, minimal image with the compiled binaries
 # only.
 {{#alpine}}
-FROM alpine:3.15.0
+FROM alpine:3.18
 {{#firefox}}
 # curl tries to load the CA certificates for libnss.
 # It loads them from /usr/lib/libnssckbi.so,
@@ -238,14 +240,15 @@ RUN apk add --no-cache nss
 {{/firefox}}
 {{/alpine}}
 {{#debian}}
-FROM debian:bullseye-slim
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates \
 {{#firefox}}
 # curl tries to load the CA certificates for libnss.
 # It loads them from /usr/lib/libnssckbi.so and /usr/lib/libnsspem.so,
 # which are supplied by 'libnss3' and 'nss-plugin-pem' on debian.
-RUN apt-get install -y libnss3 nss-plugin-pem
+    libnss3 nss-plugin-pem \
 {{/firefox}}
+    && rm -rf /var/lib/apt/lists/*
 {{/debian}}
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -34,6 +34,16 @@ RUN apt-get install -y autoconf automake autotools-dev pkg-config libtool
 RUN apk add autoconf automake pkgconfig libtool
 {{/alpine}}
 
+{{#debian}}
+# Dependencies for downloading and building nghttp2
+RUN apt-get install -y bzip2
+{{/debian}}
+
+{{#debian}}
+# Dependencies for downloading and building curl
+RUN apt-get install -y xz-utils
+{{/debian}}
+
 {{#firefox}}
 # Dependencies for building libnss
 # See https://firefox-source-docs.mozilla.org/security/nss/build.html#mozilla-projects-nss-building
@@ -111,11 +121,6 @@ RUN mkdir boringssl/build/lib && \
     cp -R boringssl/include boringssl/build
 {{/chrome}}
 
-# Dependencies for downloading and building nghttp2
-{{#debian}}
-RUN apt-get install -y bzip2
-{{/debian}}
-
 ARG NGHTTP2_VERSION=nghttp2-1.56.0
 ARG NGHTTP2_URL=https://github.com/nghttp2/nghttp2/releases/download/v1.56.0/nghttp2-1.56.0.tar.bz2
 
@@ -127,11 +132,6 @@ RUN tar xf ${NGHTTP2_VERSION}.tar.bz2
 RUN cd ${NGHTTP2_VERSION} && \
     ./configure --prefix=/build/${NGHTTP2_VERSION}/installed --with-pic --disable-shared && \
     make && make install
-
-# Dependencies for downloading and building curl
-{{#debian}}
-RUN apt-get install -y xz-utils
-{{/debian}}
 
 # Download curl.
 ARG CURL_VERSION=curl-8.1.1

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,9 +3,10 @@
 This guide shows how to compile and install curl-impersonate and libcurl-impersonate from source.
 The build process takes care of downloading dependencies, patching them, compiling them and finally compiling curl itself with the needed patches.
 There are currently three build options depending on your use case:
-* [Native build](#Native-build) using an autotools-based Makefile
-* [Cross compiling](#Cross-compiling) using an autotools-based Makefile
-* [Docker container build](#Docker-build)
+
+* [Native build](#native-build) using an autotools-based Makefile
+* [Cross compiling](#cross-compiling) using an autotools-based Makefile
+* [Docker container build](#docker-build)
 
 There are two versions of `curl-impersonate` for technical reasons. The **chrome** version is used to impersonate Chrome, Edge and Safari. The **firefox** version is used to impersonate Firefox.
 
@@ -14,7 +15,8 @@ There are two versions of `curl-impersonate` for technical reasons. The **chrome
 ### Ubuntu
 
 Install dependencies for building all the components:
-```
+
+```sh
 sudo apt install build-essential pkg-config cmake ninja-build curl autoconf automake libtool
 # For the Firefox version only
 sudo apt install python3-pip libnss3
@@ -25,13 +27,15 @@ sudo apt install golang-go unzip
 ```
 
 Clone this repository:
-```
+
+```sh
 git clone https://github.com/lwthiker/curl-impersonate.git
 cd curl-impersonate
 ```
 
 Configure and compile:
-```
+
+```sh
 mkdir build && cd build
 ../configure
 # Build and install the Firefox version
@@ -49,13 +53,15 @@ cd ../ && rm -Rf build
 This will install curl-impersonate, libcurl-impersonate and the wrapper scripts to `/usr/local`. To change the installation path, pass `--prefix=/path/to/install/` to the `configure` script.
 
 After installation you can run the wrapper scripts, e.g.:
-```
+
+```sh
 curl_ff98 https://www.wikipedia.org
 curl_chrome99 https://www.wikipedia.org
 ```
 
 or run directly with you own flags:
-```
+
+```sh
 curl-impersonate-ff https://www.wikipedia.org
 curl-impersonate-chrome https://www.wikipedia.org
 ```
@@ -63,7 +69,8 @@ curl-impersonate-chrome https://www.wikipedia.org
 ### Red Hat based (CentOS/Fedora/Amazon Linux)
 
 Install dependencies:
-```
+
+```sh
 yum groupinstall "Development Tools"
 yum groupinstall "C Development Tools and Libraries" # Fedora only
 yum install cmake3 python3 python3-pip
@@ -74,22 +81,26 @@ pip3 install ninja
 ```
 
 For the Firefox version, install NSS and gyp:
-```
+
+```sh
 yum install nss nss-pem
 pip3 install gyp-next
 ```
 
 For the Chrome version, install Go.
 You may need to follow the [Go installation instructions](https://go.dev/doc/install) if it's not packaged for your system:
-```
+
+```sh
 yum install golang
 ```
 
 Then follow the 'Ubuntu' instructions for the actual build.
 
 ### macOS
+
 Install dependencies for building all the components:
-```
+
+```sh
 brew install pkg-config make cmake ninja autoconf automake libtool
 # For the Firefox version only
 brew install sqlite nss
@@ -99,7 +110,8 @@ brew install go
 ```
 
 Configure and compile:
-```
+
+```sh
 mkdir build && cd build
 ../configure
 # Build and install the Firefox version
@@ -113,19 +125,25 @@ cd ../ && rm -Rf build
 ```
 
 ### Static compilation
+
 To compile curl-impersonate statically with libcurl-impersonate, pass `--enable-static` to the `configure` script.
 
 ### A note about the Firefox version
+
 The Firefox version compiles a static version of nss, Firefox's TLS library.
 For NSS to have a list of root certificates, curl attempts to load at runtime `libnssckbi`, one of the NSS libraries.
 If you get the error:
-```
+
+```sh
 curl: (60) Peer's Certificate issuer is not recognized
 ```
+
 or
-```
+
+```sh
 curl: (77) Problem with the SSL CA cert (path? access rights?)
 ```
+
 , make sure that NSS is installed (see above).
 If the issue persists it might be that NSS is installed in a non-standard location on your system.
 Please open an issue in that case.
@@ -135,11 +153,13 @@ Please open an issue in that case.
 There is some basic support for cross compiling curl-impersonate.
 It is currently being used to build curl-impersonate for ARM64 (aarch64) systems from x86-64 systems.
 Cross compiling is similar to the usual build but a bit trickier:
+
 * You'd have to build zlib for the target architecture so that curl can link with it.
 * Some paths have to be specified manually since curl's own build system can't determine their location.
 
 An example build for aarch64 on Ubuntu x86_64:
-```
+
+```sh
 sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
 ./configure --host=aarch64-linux-gnu \
@@ -151,20 +171,26 @@ sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 make chrome-build
 make firefox-build
 ```
+
 The flags mean as follows:
 `--with-zlib` is the location of a compiled zlib library for the target architecture.
 `--with-ca-path` and `--with-ca-bundle` will be passed to curl's configure script as is.
 `--with-libnssckbi` indicates the location of libnssckbi.so on the target system. This file contains the certificates needed by curl. This must be supplied if NSS is not installed in a standard location (i.e. not in `/usr/lib`).
 
 ## Docker build
+
 The Docker build is a bit more reproducible and serves as the reference implementation. It creates a Debian-based Docker image with the binaries.
 
 ### Chrome version
+
 [`chrome/Dockerfile`](chrome/Dockerfile) is a debian-based Dockerfile that will build curl with all the necessary modifications and patches. Build it like the following:
-```
+
+```sh
 docker build -t curl-impersonate-chrome chrome/
 ```
+
 The resulting binaries and libraries are in the `/usr/local` directory, which contains:
+
 * `curl-impersonate-chrome`, `curl-impersonate` - The curl binary that can impersonate Chrome/Edge/Safari. It is compiled statically against libcurl, BoringSSL, and libnghttp2 so that it won't conflict with any existing libraries on your system. You can use it from the container or copy it out. Tested to work on Ubuntu 20.04.
 * `curl_chrome99`, `curl_chrome100`, `...` - Wrapper scripts that launch `curl-impersonate` with all the needed flags.
 * `libcurl-impersonate-chrome.so`, `libcurl-impersonate.so` - libcurl compiled with impersonation support. See [libcurl-impersonate](README.md#libcurl-impersonate) for more details.
@@ -172,14 +198,19 @@ The resulting binaries and libraries are in the `/usr/local` directory, which co
 You can use them inside the docker, copy them out using `docker cp` or use them in a multi-stage docker build.
 
 ### Firefox version
+
 Build with:
-```
+
+```sh
 docker build -t curl-impersonate-ff firefox/
 ```
+
 The resulting binaries and libraries are in the `/usr/local` directory, which contains:
+
 * `curl-impersonate-ff`, `curl-impersonate` - The curl binary that can impersonate Firefox. It is compiled statically against libcurl, nss, and libnghttp2 so that it won't conflict with any existing libraries on your system. You can use it from the container or copy it out. Tested to work on Ubuntu 20.04.
 * `curl_ff91esr`, `curl_ff95`, `...` - Wrapper scripts that launch `curl-impersonate` with all the needed flags.
 * `libcurl-impersonate-ff.so`, `libcurl-impersonate.so` - libcurl compiled with impersonation support. See [libcurl-impersonate](README.md#libcurl-impersonate) for more details.
 
 If you use it outside the container, install the following dependency:
+
 * `sudo apt install libnss3`.  Even though nss is statically compiled into `curl-impersonate`, it is still necessary to install libnss3 because curl dynamically loads `libnssckbi.so`, a file containing Mozilla's list of trusted root certificates. Alternatively, use `curl -k` to disable certificate verification.

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -44,7 +44,9 @@ COPY patches/boringssl-*.patch boringssl/
 RUN cd boringssl && \
     for p in $(ls boringssl-*.patch); do patch -p1 < $p; done && \
     mkdir build && cd build && \
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=on -GNinja .. && \
+    cmake \
+        -DCMAKE_C_FLAGS="-Wno-error=array-bounds -Wno-error=stringop-overflow" \
+        -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=on -GNinja .. && \
     ninja
 
 # Fix the directory structure so that curl can compile against it.
@@ -53,6 +55,9 @@ RUN mkdir boringssl/build/lib && \
     ln -s ../crypto/libcrypto.a boringssl/build/lib/libcrypto.a && \
     ln -s ../ssl/libssl.a boringssl/build/lib/libssl.a && \
     cp -R boringssl/include boringssl/build
+
+# Dependencies for downloading and building nghttp2
+RUN apt-get install -y bzip2
 
 ARG NGHTTP2_VERSION=nghttp2-1.46.0
 ARG NGHTTP2_URL=https://github.com/nghttp2/nghttp2/releases/download/v1.46.0/nghttp2-1.46.0.tar.bz2
@@ -65,6 +70,9 @@ RUN tar xf ${NGHTTP2_VERSION}.tar.bz2
 RUN cd ${NGHTTP2_VERSION} && \
     ./configure --prefix=/build/${NGHTTP2_VERSION}/installed --with-pic --disable-shared && \
     make && make install
+
+# Dependencies for downloading and building curl
+RUN apt-get install -y xz-utils
 
 # Download curl.
 ARG CURL_VERSION=curl-7.84.0

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -8,7 +8,6 @@
 # Python is needed for building libnss.
 # Use it as a common base.
 FROM python:3.11-slim-bookworm as builder
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 WORKDIR /build
 

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -19,6 +19,12 @@ RUN apt-get update && \
 # both for libnghttp2 and curl.
 RUN apt-get install -y autoconf automake autotools-dev pkg-config libtool
 
+# Dependencies for downloading and building nghttp2
+RUN apt-get install -y bzip2
+
+# Dependencies for downloading and building curl
+RUN apt-get install -y xz-utils
+
 # Dependencies for downloading and building BoringSSL
 RUN apt-get install -y g++ golang-go unzip
 
@@ -56,9 +62,6 @@ RUN mkdir boringssl/build/lib && \
     ln -s ../ssl/libssl.a boringssl/build/lib/libssl.a && \
     cp -R boringssl/include boringssl/build
 
-# Dependencies for downloading and building nghttp2
-RUN apt-get install -y bzip2
-
 ARG NGHTTP2_VERSION=nghttp2-1.56.0
 ARG NGHTTP2_URL=https://github.com/nghttp2/nghttp2/releases/download/v1.56.0/nghttp2-1.56.0.tar.bz2
 
@@ -70,9 +73,6 @@ RUN tar xf ${NGHTTP2_VERSION}.tar.bz2
 RUN cd ${NGHTTP2_VERSION} && \
     ./configure --prefix=/build/${NGHTTP2_VERSION}/installed --with-pic --disable-shared && \
     make && make install
-
-# Dependencies for downloading and building curl
-RUN apt-get install -y xz-utils
 
 # Download curl.
 ARG CURL_VERSION=curl-8.1.1

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -1,13 +1,14 @@
 #
 # NOTE: THIS DOCKERFILE IS GENERATED FROM "Dockerfile.template" VIA
-# "generate-dockerfiles.sh".
+# `./generate_dockerfiles.sh`
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
 # Python is needed for building libnss.
 # Use it as a common base.
-FROM python:3.10.1-slim-bullseye as builder
+FROM python:3.11-slim-bookworm as builder
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 WORKDIR /build
 
@@ -137,8 +138,9 @@ RUN chmod +x out/curl_*
 
 # Create a final, minimal image with the compiled binaries
 # only.
-FROM debian:bullseye-slim
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
 # Update the loader's cache

--- a/chrome/Dockerfile.alpine
+++ b/chrome/Dockerfile.alpine
@@ -16,6 +16,8 @@ RUN apk add git bash build-base make cmake ninja curl zlib-dev patch linux-heade
 # both for libnghttp2 and curl.
 RUN apk add autoconf automake pkgconfig libtool
 
+
+
 # Dependencies for downloading and building BoringSSL
 RUN apk add g++ go unzip
 
@@ -53,8 +55,6 @@ RUN mkdir boringssl/build/lib && \
     ln -s ../ssl/libssl.a boringssl/build/lib/libssl.a && \
     cp -R boringssl/include boringssl/build
 
-# Dependencies for downloading and building nghttp2
-
 ARG NGHTTP2_VERSION=nghttp2-1.56.0
 ARG NGHTTP2_URL=https://github.com/nghttp2/nghttp2/releases/download/v1.56.0/nghttp2-1.56.0.tar.bz2
 
@@ -66,8 +66,6 @@ RUN tar xf ${NGHTTP2_VERSION}.tar.bz2
 RUN cd ${NGHTTP2_VERSION} && \
     ./configure --prefix=/build/${NGHTTP2_VERSION}/installed --with-pic --disable-shared && \
     make && make install
-
-# Dependencies for downloading and building curl
 
 # Download curl.
 ARG CURL_VERSION=curl-8.1.1

--- a/chrome/Dockerfile.alpine
+++ b/chrome/Dockerfile.alpine
@@ -1,16 +1,17 @@
 #
 # NOTE: THIS DOCKERFILE IS GENERATED FROM "Dockerfile.template" VIA
-# "generate-dockerfiles.sh".
+# `./generate_dockerfiles.sh`
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.15.0 as builder
+FROM alpine:3.18 as builder
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 WORKDIR /build
 
 # Common dependencies
-RUN apk add git build-base make cmake ninja curl zlib-dev patch linux-headers python3 python3-dev
+RUN apk add git bash build-base make cmake ninja curl zlib-dev patch linux-headers python3 python3-dev
 
 # The following are needed because we are going to change some autoconf scripts,
 # both for libnghttp2 and curl.
@@ -136,7 +137,7 @@ RUN chmod +x out/curl_*
 
 # Create a final, minimal image with the compiled binaries
 # only.
-FROM alpine:3.15.0
+FROM alpine:3.18
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
 # Wrapper scripts

--- a/chrome/Dockerfile.alpine
+++ b/chrome/Dockerfile.alpine
@@ -41,7 +41,9 @@ COPY patches/boringssl-*.patch boringssl/
 RUN cd boringssl && \
     for p in $(ls boringssl-*.patch); do patch -p1 < $p; done && \
     mkdir build && cd build && \
-    cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=on -GNinja .. && \
+    cmake \
+        -DCMAKE_C_FLAGS="-Wno-error=array-bounds -Wno-error=stringop-overflow" \
+        -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=on -GNinja .. && \
     ninja
 
 # Fix the directory structure so that curl can compile against it.
@@ -50,6 +52,8 @@ RUN mkdir boringssl/build/lib && \
     ln -s ../crypto/libcrypto.a boringssl/build/lib/libcrypto.a && \
     ln -s ../ssl/libssl.a boringssl/build/lib/libssl.a && \
     cp -R boringssl/include boringssl/build
+
+# Dependencies for downloading and building nghttp2
 
 ARG NGHTTP2_VERSION=nghttp2-1.46.0
 ARG NGHTTP2_URL=https://github.com/nghttp2/nghttp2/releases/download/v1.46.0/nghttp2-1.46.0.tar.bz2
@@ -62,6 +66,8 @@ RUN tar xf ${NGHTTP2_VERSION}.tar.bz2
 RUN cd ${NGHTTP2_VERSION} && \
     ./configure --prefix=/build/${NGHTTP2_VERSION}/installed --with-pic --disable-shared && \
     make && make install
+
+# Dependencies for downloading and building curl
 
 # Download curl.
 ARG CURL_VERSION=curl-7.84.0

--- a/chrome/Dockerfile.alpine
+++ b/chrome/Dockerfile.alpine
@@ -6,7 +6,6 @@
 #
 
 FROM alpine:3.18 as builder
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 WORKDIR /build
 

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -8,7 +8,6 @@
 # Python is needed for building libnss.
 # Use it as a common base.
 FROM python:3.11-slim-bookworm as builder
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 WORKDIR /build
 

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -19,6 +19,12 @@ RUN apt-get update && \
 # both for libnghttp2 and curl.
 RUN apt-get install -y autoconf automake autotools-dev pkg-config libtool
 
+# Dependencies for downloading and building nghttp2
+RUN apt-get install -y bzip2
+
+# Dependencies for downloading and building curl
+RUN apt-get install -y xz-utils
+
 # Dependencies for building libnss
 # See https://firefox-source-docs.mozilla.org/security/nss/build.html#mozilla-projects-nss-building
 RUN apt-get install -y mercurial python3-pip
@@ -50,9 +56,6 @@ RUN tar xf ${NSS_VERSION}.tar.gz && \
     cd ${NSS_VERSION}/nss && \
     ./build.sh -o --disable-tests --static --python=python3
 
-# Dependencies for downloading and building nghttp2
-RUN apt-get install -y bzip2
-
 ARG NGHTTP2_VERSION=nghttp2-1.56.0
 ARG NGHTTP2_URL=https://github.com/nghttp2/nghttp2/releases/download/v1.56.0/nghttp2-1.56.0.tar.bz2
 
@@ -64,9 +67,6 @@ RUN tar xf ${NGHTTP2_VERSION}.tar.bz2
 RUN cd ${NGHTTP2_VERSION} && \
     ./configure --prefix=/build/${NGHTTP2_VERSION}/installed --with-pic --disable-shared && \
     make && make install
-
-# Dependencies for downloading and building curl
-RUN apt-get install -y xz-utils
 
 # Download curl.
 ARG CURL_VERSION=curl-8.1.1

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -1,13 +1,14 @@
 #
 # NOTE: THIS DOCKERFILE IS GENERATED FROM "Dockerfile.template" VIA
-# "generate-dockerfiles.sh".
+# `./generate_dockerfiles.sh`
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
 # Python is needed for building libnss.
 # Use it as a common base.
-FROM python:3.10.1-slim-bullseye as builder
+FROM python:3.11-slim-bookworm as builder
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 WORKDIR /build
 
@@ -133,12 +134,13 @@ RUN chmod +x out/curl_*
 
 # Create a final, minimal image with the compiled binaries
 # only.
-FROM debian:bullseye-slim
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates \
 # curl tries to load the CA certificates for libnss.
 # It loads them from /usr/lib/libnssckbi.so and /usr/lib/libnsspem.so,
 # which are supplied by 'libnss3' and 'nss-plugin-pem' on debian.
-RUN apt-get install -y libnss3 nss-plugin-pem
+    libnss3 nss-plugin-pem \
+    && rm -rf /var/lib/apt/lists/*
 # Copy curl-impersonate from the builder image
 COPY --from=builder /build/install /usr/local
 # Update the loader's cache

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -50,6 +50,9 @@ RUN tar xf ${NSS_VERSION}.tar.gz && \
     cd ${NSS_VERSION}/nss && \
     ./build.sh -o --disable-tests --static --python=python3
 
+# Dependencies for downloading and building nghttp2
+RUN apt-get install -y bzip2
+
 ARG NGHTTP2_VERSION=nghttp2-1.46.0
 ARG NGHTTP2_URL=https://github.com/nghttp2/nghttp2/releases/download/v1.46.0/nghttp2-1.46.0.tar.bz2
 
@@ -61,6 +64,9 @@ RUN tar xf ${NGHTTP2_VERSION}.tar.bz2
 RUN cd ${NGHTTP2_VERSION} && \
     ./configure --prefix=/build/${NGHTTP2_VERSION}/installed --with-pic --disable-shared && \
     make && make install
+
+# Dependencies for downloading and building curl
+RUN apt-get install -y xz-utils
 
 # Download curl.
 ARG CURL_VERSION=curl-7.84.0

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -16,6 +16,8 @@ RUN apk add git bash build-base make cmake ninja curl zlib-dev patch linux-heade
 # both for libnghttp2 and curl.
 RUN apk add autoconf automake pkgconfig libtool
 
+
+
 # Dependencies for building libnss
 # See https://firefox-source-docs.mozilla.org/security/nss/build.html#mozilla-projects-nss-building
 RUN apk add mercurial py3-pip clang-analyzer
@@ -43,8 +45,6 @@ RUN tar xf ${NSS_VERSION}.tar.gz && \
     cd ${NSS_VERSION}/nss && \
     ./build.sh -o --disable-tests --static --python=python3
 
-# Dependencies for downloading and building nghttp2
-
 ARG NGHTTP2_VERSION=nghttp2-1.56.0
 ARG NGHTTP2_URL=https://github.com/nghttp2/nghttp2/releases/download/v1.56.0/nghttp2-1.56.0.tar.bz2
 
@@ -56,8 +56,6 @@ RUN tar xf ${NGHTTP2_VERSION}.tar.bz2
 RUN cd ${NGHTTP2_VERSION} && \
     ./configure --prefix=/build/${NGHTTP2_VERSION}/installed --with-pic --disable-shared && \
     make && make install
-
-# Dependencies for downloading and building curl
 
 # Download curl.
 ARG CURL_VERSION=curl-8.1.1

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -1,16 +1,17 @@
 #
 # NOTE: THIS DOCKERFILE IS GENERATED FROM "Dockerfile.template" VIA
-# "generate-dockerfiles.sh".
+# `./generate_dockerfiles.sh`
 #
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM alpine:3.15.0 as builder
+FROM alpine:3.18 as builder
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 WORKDIR /build
 
 # Common dependencies
-RUN apk add git build-base make cmake ninja curl zlib-dev patch linux-headers python3 python3-dev
+RUN apk add git bash build-base make cmake ninja curl zlib-dev patch linux-headers python3 python3-dev
 
 # The following are needed because we are going to change some autoconf scripts,
 # both for libnghttp2 and curl.
@@ -128,7 +129,7 @@ RUN chmod +x out/curl_*
 
 # Create a final, minimal image with the compiled binaries
 # only.
-FROM alpine:3.15.0
+FROM alpine:3.18
 # curl tries to load the CA certificates for libnss.
 # It loads them from /usr/lib/libnssckbi.so,
 # which is supplied by 'nss' on alpine.

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -6,7 +6,6 @@
 #
 
 FROM alpine:3.18 as builder
-SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
 WORKDIR /build
 

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -43,6 +43,8 @@ RUN tar xf ${NSS_VERSION}.tar.gz && \
     cd ${NSS_VERSION}/nss && \
     ./build.sh -o --disable-tests --static --python=python3
 
+# Dependencies for downloading and building nghttp2
+
 ARG NGHTTP2_VERSION=nghttp2-1.46.0
 ARG NGHTTP2_URL=https://github.com/nghttp2/nghttp2/releases/download/v1.46.0/nghttp2-1.46.0.tar.bz2
 
@@ -54,6 +56,8 @@ RUN tar xf ${NGHTTP2_VERSION}.tar.bz2
 RUN cd ${NGHTTP2_VERSION} && \
     ./configure --prefix=/build/${NGHTTP2_VERSION}/installed --with-pic --disable-shared && \
     make && make install
+
+# Dependencies for downloading and building curl
 
 # Download curl.
 ARG CURL_VERSION=curl-7.84.0

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -4,7 +4,7 @@ ARG CHROME_IMAGE=curl-impersonate-chrome
 FROM ${FIREFOX_IMAGE} as ff
 FROM ${CHROME_IMAGE} as chrome
 
-FROM python:3.10.1-slim-bullseye
+FROM python:3.11-slim-bookworm
 
 WORKDIR /tests
 


### PR DESCRIPTION
Hello,
I noticed some Docker base images were getting a bit old, so:

* Update to current versions: python:3.11-slim-bookworm, debian:bookworm-slim, alpine:3.18
* Reduce size of Debian image (remove apt cache) by 10MB
* ~~Add pipefail (which I needed during test), cf. https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/~~
* And also minor Markdown lint of INSTALL.md