### PR TITLE
Upgrade nss to 3.92

### DIFF
--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -92,9 +92,9 @@ jobs:
       # When cross compiling we need to build zlib first.
       - name: Build zlib
         run: |
-          curl -LO https://zlib.net/zlib-1.2.13.tar.gz
-          tar xf zlib-1.2.13.tar.gz
-          cd zlib-1.2.13
+          curl -LO https://zlib.net/zlib-1.3.tar.gz
+          tar xf zlib-1.3.tar.gz
+          cd zlib-1.3
           CHOST=${{ matrix.host }} ./configure --prefix=${{ runner.temp }}/zlib
           make
           make install

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -74,9 +74,9 @@ RUN cd brotli-${BROTLI_VERSION} && \
 # Needed for building libnss
 RUN pip install gyp-next
 
-ARG NSS_VERSION=nss-3.77
+ARG NSS_VERSION=nss-3.92
 # This tarball is already bundled with nspr, a dependency of libnss.
-ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_77_RTM/src/nss-3.77-with-nspr-4.32.tar.gz
+ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_92_RTM/src/nss-3.92-with-nspr-4.35.tar.gz
 
 # Download and compile nss.
 RUN curl -o ${NSS_VERSION}.tar.gz ${NSS_URL}

--- a/Makefile.in
+++ b/Makefile.in
@@ -10,8 +10,8 @@ SHELL := bash
 
 BROTLI_VERSION := 1.0.9
  # In case this is changed, update build-and-test-make.yml as well
-NSS_VERSION := nss-3.87
-NSS_URL := https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_87_RTM/src/nss-3.87-with-nspr-4.35.tar.gz
+NSS_VERSION := nss-3.92
+NSS_URL := https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_92_RTM/src/nss-3.92-with-nspr-4.35.tar.gz
  # In case this is changed, update build-and-test-make.yml as well
 BORING_SSL_COMMIT := 3a667d10e94186fd503966f5638e134fe9fb4080
 NGHTTP2_VERSION := nghttp2-1.46.0

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -40,9 +40,9 @@ RUN cd brotli-${BROTLI_VERSION} && \
 # Needed for building libnss
 RUN pip install gyp-next
 
-ARG NSS_VERSION=nss-3.77
+ARG NSS_VERSION=nss-3.92
 # This tarball is already bundled with nspr, a dependency of libnss.
-ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_77_RTM/src/nss-3.77-with-nspr-4.32.tar.gz
+ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_92_RTM/src/nss-3.92-with-nspr-4.35.tar.gz
 
 # Download and compile nss.
 RUN curl -o ${NSS_VERSION}.tar.gz ${NSS_URL}

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -33,9 +33,9 @@ RUN cd brotli-${BROTLI_VERSION} && \
 # Needed for building libnss
 RUN pip install gyp-next
 
-ARG NSS_VERSION=nss-3.77
+ARG NSS_VERSION=nss-3.92
 # This tarball is already bundled with nspr, a dependency of libnss.
-ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_77_RTM/src/nss-3.77-with-nspr-4.32.tar.gz
+ARG NSS_URL=https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_92_RTM/src/nss-3.92-with-nspr-4.35.tar.gz
 
 # Download and compile nss.
 RUN curl -o ${NSS_VERSION}.tar.gz ${NSS_URL}


### PR DESCRIPTION
The nss version currently in use does not build with gcc 13. Upgrade to nss 3.92.