### PR TITLE
Fix BoringSSL include path

### DIFF
--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -92,9 +92,9 @@ jobs:
       # When cross compiling we need to build zlib first.
       - name: Build zlib
         run: |
-          curl -LO https://zlib.net/zlib-1.2.13.tar.gz
-          tar xf zlib-1.2.13.tar.gz
-          cd zlib-1.2.13
+          curl -LO https://zlib.net/zlib-1.3.tar.gz
+          tar xf zlib-1.3.tar.gz
+          cd zlib-1.3
           CHOST=${{ matrix.host }} ./configure --prefix=${{ runner.temp }}/zlib
           make
           make install

--- a/Makefile.in
+++ b/Makefile.in
@@ -423,7 +423,7 @@ $(CURL_VERSION)/.chrome: $(chrome_libs)	$(CURL_VERSION).tar.xz $(CURL_VERSION)/.
 		config_flags="$$config_flags --with-ca-path=$(with_ca_path)"; \
 	  fi; \
 	  add_libs="-pthread"; \
-	  add_cflags="-I$(boringssl_install_dir)"; \
+	  add_cflags="-I$(boringssl_install_dir)/include"; \
 	}
 
 	echo "Configuring curl with: $$config_flags"


### PR DESCRIPTION
A build error on Mac is caused due to the build using OpenSSL headers instead of BoringSSL. Attempt to fix that.