### PR TITLE
Remove --false-start flag

### DIFF
--- a/chrome/curl_chrome100
+++ b/chrome/curl_chrome100
@@ -20,7 +20,7 @@ dir=${0%/*}
     -H 'Sec-Fetch-Dest: document' \
     -H 'Accept-Encoding: gzip, deflate, br' \
     -H 'Accept-Language: en-US,en;q=0.9' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     --tlsv1.2 --alps \
     --cert-compression brotli \
     "$@"

--- a/chrome/curl_chrome101
+++ b/chrome/curl_chrome101
@@ -20,7 +20,7 @@ dir=${0%/*}
     -H 'Sec-Fetch-Dest: document' \
     -H 'Accept-Encoding: gzip, deflate, br' \
     -H 'Accept-Language: en-US,en;q=0.9' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     --tlsv1.2 --alps \
     --cert-compression brotli \
     "$@"

--- a/chrome/curl_chrome104
+++ b/chrome/curl_chrome104
@@ -20,7 +20,7 @@ dir=${0%/*}
     -H 'Sec-Fetch-Dest: document' \
     -H 'Accept-Encoding: gzip, deflate, br' \
     -H 'Accept-Language: en-US,en;q=0.9' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     --tlsv1.2 --alps \
     --cert-compression brotli \
     "$@"

--- a/chrome/curl_chrome107
+++ b/chrome/curl_chrome107
@@ -20,7 +20,7 @@ dir=${0%/*}
     -H 'Sec-Fetch-Dest: document' \
     -H 'Accept-Encoding: gzip, deflate, br' \
     -H 'Accept-Language: en-US,en;q=0.9' \
-    --http2 --http2-no-server-push --false-start --compressed \
+    --http2 --http2-no-server-push --compressed \
     --tlsv1.2 --alps \
     --cert-compression brotli \
     "$@"

--- a/chrome/curl_chrome110
+++ b/chrome/curl_chrome110
@@ -20,7 +20,7 @@ dir=${0%/*}
     -H 'Sec-Fetch-Dest: document' \
     -H 'Accept-Encoding: gzip, deflate, br' \
     -H 'Accept-Language: en-US,en;q=0.9' \
-    --http2 --http2-no-server-push --false-start --compressed \
+    --http2 --http2-no-server-push --compressed \
     --tlsv1.2 --alps --tls-permute-extensions \
     --cert-compression brotli \
     "$@"

--- a/chrome/curl_chrome116
+++ b/chrome/curl_chrome116
@@ -20,7 +20,7 @@ dir=${0%/*}
     -H 'Sec-Fetch-Dest: document' \
     -H 'Accept-Encoding: gzip, deflate, br' \
     -H 'Accept-Language: en-US,en;q=0.9' \
-    --http2 --http2-no-server-push --false-start --compressed \
+    --http2 --http2-no-server-push --compressed \
     --tlsv1.2 --alps --tls-permute-extensions \
     --cert-compression brotli \
     "$@"

--- a/chrome/curl_chrome99
+++ b/chrome/curl_chrome99
@@ -20,7 +20,7 @@ dir=${0%/*}
     -H 'Sec-Fetch-Dest: document' \
     -H 'Accept-Encoding: gzip, deflate, br' \
     -H 'Accept-Language: en-US,en;q=0.9' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     --tlsv1.2 --alps \
     --cert-compression brotli \
     "$@"

--- a/chrome/curl_chrome99_android
+++ b/chrome/curl_chrome99_android
@@ -20,7 +20,7 @@ dir=${0%/*}
     -H 'Sec-Fetch-Dest: document' \
     -H 'Accept-Encoding: gzip, deflate, br' \
     -H 'Accept-Language: en-US,en;q=0.9' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     --tlsv1.2 --alps \
     --cert-compression brotli \
     "$@"

--- a/chrome/curl_edge101
+++ b/chrome/curl_edge101
@@ -20,7 +20,7 @@ dir=${0%/*}
     -H 'Sec-Fetch-Dest: document' \
     -H 'Accept-Encoding: gzip, deflate, br' \
     -H 'Accept-Language: en-US,en;q=0.9' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     --tlsv1.2 --alps \
     --cert-compression brotli \
     "$@"

--- a/chrome/curl_edge99
+++ b/chrome/curl_edge99
@@ -20,7 +20,7 @@ dir=${0%/*}
     -H 'Sec-Fetch-Dest: document' \
     -H 'Accept-Encoding: gzip, deflate, br' \
     -H 'Accept-Language: en-US,en;q=0.9' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     --tlsv1.2 --alps \
     --cert-compression brotli \
     "$@"

--- a/chrome/curl_safari15_3
+++ b/chrome/curl_safari15_3
@@ -14,7 +14,7 @@ dir=${0%/*}
     -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' \
     -H 'Accept-Language: en-us' \
     -H 'Accept-Encoding: gzip, deflate, br' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     --tlsv1.0 --no-tls-session-ticket \
     --http2-pseudo-headers-order 'mspa' \
     "$@"

--- a/chrome/curl_safari15_5
+++ b/chrome/curl_safari15_5
@@ -14,7 +14,7 @@ dir=${0%/*}
     -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8' \
     -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
     -H 'Accept-Encoding: gzip, deflate, br' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     --tlsv1.0 --no-tls-session-ticket \
     --cert-compression zlib \
     --http2-pseudo-headers-order 'mspa' \

--- a/docs/02_USAGE.md
+++ b/docs/02_USAGE.md
@@ -50,7 +50,7 @@ The important part of the script is:
     -H 'Sec-Fetch-Dest: document' \
     -H 'Accept-Encoding: gzip, deflate, br' \
     -H 'Accept-Language: en-US,en;q=0.9' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     --tlsv1.2 --no-npn --alps \
     --cert-compression brotli \
     "$@"

--- a/firefox/curl_ff100
+++ b/firefox/curl_ff100
@@ -18,5 +18,5 @@ dir=${0%/*}
     -H 'Sec-Fetch-Site: none' \
     -H 'Sec-Fetch-User: ?1' \
     -H 'TE: Trailers' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     "$@"

--- a/firefox/curl_ff102
+++ b/firefox/curl_ff102
@@ -18,5 +18,5 @@ dir=${0%/*}
     -H 'Sec-Fetch-Site: none' \
     -H 'Sec-Fetch-User: ?1' \
     -H 'TE: Trailers' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     "$@"

--- a/firefox/curl_ff109
+++ b/firefox/curl_ff109
@@ -18,5 +18,5 @@ dir=${0%/*}
     -H 'Sec-Fetch-Site: none' \
     -H 'Sec-Fetch-User: ?1' \
     -H 'TE: Trailers' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     "$@"

--- a/firefox/curl_ff117
+++ b/firefox/curl_ff117
@@ -18,5 +18,5 @@ dir=${0%/*}
     -H 'Sec-Fetch-Site: none' \
     -H 'Sec-Fetch-User: ?1' \
     -H 'TE: Trailers' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     "$@"

--- a/firefox/curl_ff91esr
+++ b/firefox/curl_ff91esr
@@ -18,5 +18,5 @@ dir=${0%/*}
     -H 'Sec-Fetch-Site: none' \
     -H 'Sec-Fetch-User: ?1' \
     -H 'TE: Trailers' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     "$@"

--- a/firefox/curl_ff95
+++ b/firefox/curl_ff95
@@ -18,5 +18,5 @@ dir=${0%/*}
     -H 'Sec-Fetch-Site: none' \
     -H 'Sec-Fetch-User: ?1' \
     -H 'TE: Trailers' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     "$@"

--- a/firefox/curl_ff98
+++ b/firefox/curl_ff98
@@ -18,5 +18,5 @@ dir=${0%/*}
     -H 'Sec-Fetch-Site: none' \
     -H 'Sec-Fetch-User: ?1' \
     -H 'TE: Trailers' \
-    --http2 --false-start --compressed \
+    --http2 --compressed \
     "$@"


### PR DESCRIPTION
Remove the --false-start flag completely. In the Chrome version it has no affect, and in the Firefox version it may cause connection errors. This flag doesn't seem to affect TLS or HTTP signatures so is safe to remove.

The flag seems to cause connection errors with some http/2 servers. The server chooses http/2 based on alpn but curl initiates a http/1.1 connection instead. This is an upstream bug in curl that affects us as well.