### PR TITLE
Build curl with websocket support

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -150,6 +150,7 @@ RUN cd ${CURL_VERSION} && \
     ./configure --prefix=/build/install \
                 --enable-static \
                 --disable-shared \
+                --enable-websockets \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
 {{#firefox}}

--- a/Makefile.in
+++ b/Makefile.in
@@ -364,6 +364,7 @@ $(CURL_VERSION)/.firefox: $(firefox_libs) $(CURL_VERSION).tar.xz $(CURL_VERSION)
 	  config_flags+=" --with-nghttp2=$(nghttp2_install_dir)"; \
 	  config_flags+=" --with-brotli=$(brotli_install_dir)"; \
 	  config_flags+=" --with-nss=$(nss_install_dir) --with-nss-deprecated"; \
+	  config_flags+=" --enable-websockets"; \
 	  config_flags+=" USE_CURL_SSLKEYLOGFILE=true"; \
 	  if test "$(static_build)" = "yes"; then \
 	    config_flags+=" --enable-static --disable-shared"; \
@@ -404,6 +405,7 @@ $(CURL_VERSION)/.chrome: $(chrome_libs)	$(CURL_VERSION).tar.xz $(CURL_VERSION)/.
 	  config_flags="$$config_flags --with-nghttp2=$(nghttp2_install_dir)"; \
 	  config_flags="$$config_flags --with-brotli=$(brotli_install_dir)"; \
 	  config_flags="$$config_flags --with-openssl=$(boringssl_install_dir)"; \
+	  config_flags="$$config_flags --enable-websockets"; \
 	  config_flags="$$config_flags USE_CURL_SSLKEYLOGFILE=true"; \
 	  if test "$(static_build)" = "yes"; then \
 	    config_flags="$$config_flags --enable-static --disable-shared";

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -91,6 +91,7 @@ RUN cd ${CURL_VERSION} && \
     ./configure --prefix=/build/install \
                 --enable-static \
                 --disable-shared \
+                --enable-websockets \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-openssl=/build/boringssl/build \

--- a/chrome/Dockerfile.alpine
+++ b/chrome/Dockerfile.alpine
@@ -84,6 +84,7 @@ RUN cd ${CURL_VERSION} && \
     ./configure --prefix=/build/install \
                 --enable-static \
                 --disable-shared \
+                --enable-websockets \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-openssl=/build/boringssl/build \

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -85,6 +85,7 @@ RUN cd ${CURL_VERSION} && \
     ./configure --prefix=/build/install \
                 --enable-static \
                 --disable-shared \
+                --enable-websockets \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-nss=/build/${NSS_VERSION}/dist/Release \

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -74,6 +74,7 @@ RUN cd ${CURL_VERSION} && \
     ./configure --prefix=/build/install \
                 --enable-static \
                 --disable-shared \
+                --enable-websockets \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-nss=/build/${NSS_VERSION}/dist/Release \


### PR DESCRIPTION
Enable curl's websocket handling with --enable-websockets.