### PR TITLE
Fix Docker build missing websocket support

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -181,7 +181,8 @@ RUN mkdir out && \
 RUN ./out/curl-impersonate -V | grep -q zlib && \
     ./out/curl-impersonate -V | grep -q brotli && \
     ./out/curl-impersonate -V | grep -q nghttp2 && \
-    ./out/curl-impersonate -V | grep -q -e NSS -e BoringSSL
+    ./out/curl-impersonate -V | grep -q -e NSS -e BoringSSL && \
+    ./out/curl-impersonate -V | grep -q -e wss
 
 # Verify that the resulting 'curl' is really statically compiled
 RUN ! (ldd ./out/curl-impersonate | grep -q -e libcurl -e nghttp2 -e brotli -e ssl -e crypto)
@@ -191,6 +192,7 @@ RUN rm -Rf /build/install
 # Re-compile libcurl dynamically
 RUN cd ${CURL_VERSION} && \
     ./configure --prefix=/build/install \
+                --enable-websockets \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
 {{#firefox}}
@@ -262,7 +264,8 @@ RUN apt-get update && apt-get install -y ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 {{/debian}}
 # Copy curl-impersonate from the builder image
-COPY --from=builder /build/install /usr/local
+COPY --from=builder /build/out/curl-impersonate* /usr/local/bin
+COPY --from=builder /build/out/libcurl-impersonate* /usr/local/lib
 {{#debian}}
 # Update the loader's cache
 RUN ldconfig

--- a/chrome/Dockerfile
+++ b/chrome/Dockerfile
@@ -109,7 +109,8 @@ RUN mkdir out && \
 RUN ./out/curl-impersonate -V | grep -q zlib && \
     ./out/curl-impersonate -V | grep -q brotli && \
     ./out/curl-impersonate -V | grep -q nghttp2 && \
-    ./out/curl-impersonate -V | grep -q -e NSS -e BoringSSL
+    ./out/curl-impersonate -V | grep -q -e NSS -e BoringSSL && \
+    ./out/curl-impersonate -V | grep -q -e wss
 
 # Verify that the resulting 'curl' is really statically compiled
 RUN ! (ldd ./out/curl-impersonate | grep -q -e libcurl -e nghttp2 -e brotli -e ssl -e crypto)
@@ -119,6 +120,7 @@ RUN rm -Rf /build/install
 # Re-compile libcurl dynamically
 RUN cd ${CURL_VERSION} && \
     ./configure --prefix=/build/install \
+                --enable-websockets \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-openssl=/build/boringssl/build \
@@ -150,7 +152,8 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 # Copy curl-impersonate from the builder image
-COPY --from=builder /build/install /usr/local
+COPY --from=builder /build/out/curl-impersonate* /usr/local/bin
+COPY --from=builder /build/out/libcurl-impersonate* /usr/local/lib
 # Update the loader's cache
 RUN ldconfig
 # Copy to /build/out as well for backward compatibility with previous versions.

--- a/chrome/Dockerfile.alpine
+++ b/chrome/Dockerfile.alpine
@@ -102,7 +102,8 @@ RUN mkdir out && \
 RUN ./out/curl-impersonate -V | grep -q zlib && \
     ./out/curl-impersonate -V | grep -q brotli && \
     ./out/curl-impersonate -V | grep -q nghttp2 && \
-    ./out/curl-impersonate -V | grep -q -e NSS -e BoringSSL
+    ./out/curl-impersonate -V | grep -q -e NSS -e BoringSSL && \
+    ./out/curl-impersonate -V | grep -q -e wss
 
 # Verify that the resulting 'curl' is really statically compiled
 RUN ! (ldd ./out/curl-impersonate | grep -q -e libcurl -e nghttp2 -e brotli -e ssl -e crypto)
@@ -112,6 +113,7 @@ RUN rm -Rf /build/install
 # Re-compile libcurl dynamically
 RUN cd ${CURL_VERSION} && \
     ./configure --prefix=/build/install \
+                --enable-websockets \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-openssl=/build/boringssl/build \
@@ -143,6 +145,7 @@ RUN chmod +x out/curl_*
 # only.
 FROM alpine:3.18
 # Copy curl-impersonate from the builder image
-COPY --from=builder /build/install /usr/local
+COPY --from=builder /build/out/curl-impersonate* /usr/local/bin
+COPY --from=builder /build/out/libcurl-impersonate* /usr/local/lib
 # Wrapper scripts
 COPY --from=builder /build/out/curl_* /usr/local/bin/

--- a/firefox/Dockerfile
+++ b/firefox/Dockerfile
@@ -103,7 +103,8 @@ RUN mkdir out && \
 RUN ./out/curl-impersonate -V | grep -q zlib && \
     ./out/curl-impersonate -V | grep -q brotli && \
     ./out/curl-impersonate -V | grep -q nghttp2 && \
-    ./out/curl-impersonate -V | grep -q -e NSS -e BoringSSL
+    ./out/curl-impersonate -V | grep -q -e NSS -e BoringSSL && \
+    ./out/curl-impersonate -V | grep -q -e wss
 
 # Verify that the resulting 'curl' is really statically compiled
 RUN ! (ldd ./out/curl-impersonate | grep -q -e libcurl -e nghttp2 -e brotli -e ssl -e crypto)
@@ -113,6 +114,7 @@ RUN rm -Rf /build/install
 # Re-compile libcurl dynamically
 RUN cd ${CURL_VERSION} && \
     ./configure --prefix=/build/install \
+                --enable-websockets \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-nss=/build/${NSS_VERSION}/dist/Release \
@@ -148,7 +150,8 @@ RUN apt-get update && apt-get install -y ca-certificates \
     libnss3 nss-plugin-pem \
     && rm -rf /var/lib/apt/lists/*
 # Copy curl-impersonate from the builder image
-COPY --from=builder /build/install /usr/local
+COPY --from=builder /build/out/curl-impersonate* /usr/local/bin
+COPY --from=builder /build/out/libcurl-impersonate* /usr/local/lib
 # Update the loader's cache
 RUN ldconfig
 # Copy to /build/out as well for backward compatibility with previous versions.

--- a/firefox/Dockerfile.alpine
+++ b/firefox/Dockerfile.alpine
@@ -92,7 +92,8 @@ RUN mkdir out && \
 RUN ./out/curl-impersonate -V | grep -q zlib && \
     ./out/curl-impersonate -V | grep -q brotli && \
     ./out/curl-impersonate -V | grep -q nghttp2 && \
-    ./out/curl-impersonate -V | grep -q -e NSS -e BoringSSL
+    ./out/curl-impersonate -V | grep -q -e NSS -e BoringSSL && \
+    ./out/curl-impersonate -V | grep -q -e wss
 
 # Verify that the resulting 'curl' is really statically compiled
 RUN ! (ldd ./out/curl-impersonate | grep -q -e libcurl -e nghttp2 -e brotli -e ssl -e crypto)
@@ -102,6 +103,7 @@ RUN rm -Rf /build/install
 # Re-compile libcurl dynamically
 RUN cd ${CURL_VERSION} && \
     ./configure --prefix=/build/install \
+                --enable-websockets \
                 --with-nghttp2=/build/${NGHTTP2_VERSION}/installed \
                 --with-brotli=/build/brotli-${BROTLI_VERSION}/build/installed \
                 --with-nss=/build/${NSS_VERSION}/dist/Release \
@@ -137,6 +139,7 @@ FROM alpine:3.18
 # which is supplied by 'nss' on alpine.
 RUN apk add --no-cache nss
 # Copy curl-impersonate from the builder image
-COPY --from=builder /build/install /usr/local
+COPY --from=builder /build/out/curl-impersonate* /usr/local/bin
+COPY --from=builder /build/out/libcurl-impersonate* /usr/local/lib
 # Wrapper scripts
 COPY --from=builder /build/out/curl_* /usr/local/bin/


### PR DESCRIPTION
The Docker image first builds a static curl-impersonate, then builds libcurl-impersonate separately. However, the second build overrode the binary created in the first one, and was configured without websocket support in addition. This commit fixes both:
* The second build does not override the first, static build.
* The second build is configured with websockets.

Fixes #212 