### PR TITLE
Go back to macos-latest

### DIFF
--- a/.github/workflows/build-and-test-make.yml
+++ b/.github/workflows/build-and-test-make.yml
@@ -43,7 +43,7 @@ jobs:
             host: x86_64-macos
             capture_interface: en0
             make: gmake
-          - os: macos-14
+          - os: macos-latest
             arch: aarch64
             host: aarch64-macos
             capture_interface: en0


### PR DESCRIPTION
Now macos-latest is moved to Arm64, it's also based on macos-14.

See https://github.com/actions/runner-images?tab=readme-ov-file#available-images.

Follow up #223.